### PR TITLE
Fix Spaz.curse() method

### DIFF
--- a/assets/src/ba_data/python/bastd/actor/spaz.py
+++ b/assets/src/ba_data/python/bastd/actor/spaz.py
@@ -625,7 +625,7 @@ class Spaz(ba.Actor):
             else:
                 # Note: curse-death-time takes milliseconds.
                 tval = ba.time()
-                assert isinstance(tval, int)
+                assert isinstance(tval, (float, int))
                 self.node.curse_death_time = int(1000.0 *
                                                  (tval + self.curse_time))
                 ba.timer(5.0, ba.WeakCall(self.curse_explode))


### PR DESCRIPTION
Timer does not work, explodes only when touched.