### PR TITLE
Fix score sorting in co-op scorescreen activity

### DIFF
--- a/assets/src/ba_data/python/ba/_gameresults.py
+++ b/assets/src/ba_data/python/ba/_gameresults.py
@@ -189,7 +189,7 @@ class TeamGameResults:
             sval.append(team)
         results: List[Tuple[Optional[int],
                             List[ba.Team]]] = list(winners.items())
-        results.sort(reverse=not self._lower_is_better)
+        results.sort(reverse=not self._lower_is_better, key=lambda x: x[0])
 
         # Also group the 'None' scores.
         none_teams: List[ba.Team] = []

--- a/assets/src/ba_data/python/bastd/activity/coopscorescreen.py
+++ b/assets/src/ba_data/python/bastd/activity/coopscorescreen.py
@@ -676,7 +676,8 @@ class CoopScoreScreen(ba.Activity):
             our_score = None
 
         try:
-            our_high_scores.sort(reverse=self._score_order == 'increasing')
+            our_high_scores.sort(reverse=self._score_order == 'increasing',
+                                 key=lambda x: x[0])
         except Exception:
             ba.print_exception('Error sorting scores')
             print('our_high_scores:', our_high_scores)

--- a/assets/src/ba_data/python/bastd/activity/coopscorescreen.py
+++ b/assets/src/ba_data/python/bastd/activity/coopscorescreen.py
@@ -928,7 +928,8 @@ class CoopScoreScreen(ba.Activity):
                     results.remove(score)
                     break
             results.append(our_score_entry)
-            results.sort(reverse=self._score_order == 'increasing')
+            results.sort(reverse=self._score_order == 'increasing',
+                         key=lambda x: x[0])
 
         # If we're not submitting our own score, we still want to change the
         # name of our own score to 'Me'.

--- a/assets/src/ba_data/python/bastd/activity/multiteamendscreen.py
+++ b/assets/src/ba_data/python/bastd/activity/multiteamendscreen.py
@@ -80,11 +80,11 @@ class TeamSeriesVictoryScoreScreenActivity(TeamsScoreScreenActivity):
                     player_entries.append(
                         (prec.player.team.sessiondata['score'],
                          prec.get_name(full=True), prec))
-            player_entries.sort(reverse=True)
+            player_entries.sort(reverse=True, key=lambda x: x[0])
         else:
             for _pkey, prec in self.stats.get_records().items():
                 player_entries.append((prec.score, prec.name_full, prec))
-            player_entries.sort(reverse=True)
+            player_entries.sort(reverse=True, key=lambda x: x[0])
 
         ts_height = 300.0
         ts_h_offs = -390.0

--- a/assets/src/ba_data/python/bastd/game/elimination.py
+++ b/assets/src/ba_data/python/bastd/game/elimination.py
@@ -400,7 +400,8 @@ class EliminationGame(ba.TeamGameActivity):
                         self.map.get_start_position(team.get_id()))
                     points.append(
                         ((start_pos - player_pos).length(), start_pos))
-                points.sort()
+                # Hmm.. we need to sorting vectors too?
+                points.sort(key=lambda x: x[0])
                 return points[-1][1]
         return None
 

--- a/assets/src/ba_data/python/bastd/game/race.py
+++ b/assets/src/ba_data/python/bastd/game/race.py
@@ -550,9 +550,7 @@ class RaceGame(ba.TeamGameActivity):
         p_list = [[player.gamedata['distance'], player]
                   for player in self.players]
 
-        p_list.sort(reverse=True)
-        # FIXME - need another way to sort p_list.
-        # It tries to compare ba.Player objects.
+        p_list.sort(reverse=True, key=lambda x: x[0])
         for i, plr in enumerate(p_list):
             try:
                 plr[1].gamedata['rank'] = i

--- a/assets/src/ba_data/python/bastd/ui/gather.py
+++ b/assets/src/ba_data/python/bastd/ui/gather.py
@@ -1451,8 +1451,7 @@ class GatherWindow(ba.Window):
                 key=lambda p: (
                     p['queue'] is None,  # Show non-queued last.
                     p['ping'] if p['ping'] is not None else 999999,
-                    p['index'],
-                    p))
+                    p['index']))
             existing_selection = self._public_party_list_selection
             first = True
 

--- a/assets/src/ba_data/python/efro/util.py
+++ b/assets/src/ba_data/python/efro/util.py
@@ -303,4 +303,6 @@ def make_hash(obj: Any) -> int:
     for k, v in new_obj.items():
         new_obj[k] = make_hash(v)
 
+    # NOTE: there is sorted works correctly because it compares only
+    # unique first values (i.e. dict keys)
     return hash(tuple(frozenset(sorted(new_obj.items()))))


### PR DESCRIPTION
If some scores are equal, I get TypeError while Python compares dict objects.
I think that it’s also necessary to sort by time, but it will take a lot of effort and I don’t know if it is necessary.