### PR TITLE
Fix pause menu

### DIFF
--- a/assets/src/ba_data/python/bastd/ui/mainmenu.py
+++ b/assets/src/ba_data/python/bastd/ui/mainmenu.py
@@ -703,7 +703,6 @@ class MainMenuWindow(ba.Window):
             v += v_offset
             h += h_offset
             h_offset += d_h_offset
-        custom_menu_entries = []
         self._start_button = None
         ba.app.pause()
 


### PR DESCRIPTION
Functionality for adding custom menu entities didn't work correctly (in co-op sessions was no retry button).
I really don't know what this line do here:neutral_face: