### PR TITLE
Minigame fixes

### DIFF
--- a/assets/src/ba_data/python/bastd/game/elimination.py
+++ b/assets/src/ba_data/python/bastd/game/elimination.py
@@ -166,7 +166,7 @@ class Icon(ba.Actor):
         if isinstance(msg, ba.DieMessage):
             self.node.delete()
         else:
-            return super().handlemessage(msg)
+            super().handlemessage(msg)
 
 
 # ba_meta export game

--- a/assets/src/ba_data/python/bastd/game/elimination.py
+++ b/assets/src/ba_data/python/bastd/game/elimination.py
@@ -162,6 +162,12 @@ class Icon(ba.Actor):
             if lives == 0:
                 ba.timer(0.6, self.update_for_lives)
 
+    def handlemessage(self, msg: Any) -> Any:
+        if isinstance(msg, ba.DieMessage):
+            self.node.delete()
+        else:
+            return super().handlemessage(msg)
+
 
 # ba_meta export game
 class EliminationGame(ba.TeamGameActivity):

--- a/assets/src/ba_data/python/bastd/game/race.py
+++ b/assets/src/ba_data/python/bastd/game/race.py
@@ -717,8 +717,7 @@ class RaceGame(ba.TeamGameActivity):
         results = ba.TeamGameResults()
 
         for team in self.teams:
-            if team.gamedata['time'] is not None:
-                results.set_team_score(team, team.gamedata['time'])
+            results.set_team_score(team, team.gamedata['time'])
             # If game have ended before we
             # get any result, use 'fail' screen
 


### PR DESCRIPTION
1. In race, we have only one or two players in scoreboard (only that finished).
2. In Elimination, player's icon stays alive if he leaves.

Do we have any reason not to move base DieMessage handling to ba.Actor?