### PR TITLE
Exceptions cleanup and fix FFA spawn

### DIFF
--- a/assets/src/ba_data/python/ba/_account.py
+++ b/assets/src/ba_data/python/ba/_account.py
@@ -83,7 +83,7 @@ def get_league_rank_points(data: Optional[Dict[str, Any]],
         assert isinstance(trophies_total, int)
         return trophies_total
     if subset is not None:
-        raise Exception('invalid subset value: ' + str(subset))
+        raise ValueError('invalid subset value: ' + str(subset))
 
     if data['p']:
         pro_mult = 1.0 + float(

--- a/assets/src/ba_data/python/ba/_achievement.py
+++ b/assets/src/ba_data/python/ba/_achievement.py
@@ -140,7 +140,7 @@ def get_achievement(name: str) -> Achievement:
     achs = [a for a in _ba.app.achievements if a.name == name]
     assert len(achs) < 2
     if not achs:
-        raise Exception("Invalid achievement name: '" + name + "'")
+        raise ValueError("Invalid achievement name: '" + name + "'")
     return achs[0]
 
 
@@ -396,7 +396,7 @@ class Achievement:
             v_attach = Text.VAttach.TOP
             attach = Image.Attach.TOP_CENTER
         else:
-            raise Exception('invalid style "' + style + '"')
+            raise ValueError('invalid style "' + style + '"')
 
         # Attempt to determine what campaign we're in
         # (so we know whether to show "hard mode only").

--- a/assets/src/ba_data/python/ba/_activity.py
+++ b/assets/src/ba_data/python/ba/_activity.py
@@ -166,14 +166,14 @@ class Activity(DependencyComponent, Generic[PlayerType, TeamType]):
 
         session = _ba.getsession()
         if session is None:
-            raise Exception('No current session')
+            raise RuntimeError('No current session')
         self._session = weakref.ref(session)
 
         # Preloaded data for actors, maps, etc; indexed by type.
         self.preloads: Dict[Type, Any] = {}
 
         if not isinstance(settings, dict):
-            raise Exception('expected dict for settings')
+            raise TypeError('expected dict for settings')
         if _ba.getactivity(doraise=False) is not self:
             raise Exception('invalid context state')
 
@@ -292,8 +292,8 @@ class Activity(DependencyComponent, Generic[PlayerType, TeamType]):
         (internal)
         """
         if self.has_begun():
-            raise Exception('This should only be called for Activities'
-                            'that have not yet begun.')
+            raise RuntimeError('This should only be called for Activities'
+                               'that have not yet begun.')
         if not self._should_end_immediately or force:
             self._should_end_immediately = True
             self._should_end_immediately_results = results
@@ -340,7 +340,7 @@ class Activity(DependencyComponent, Generic[PlayerType, TeamType]):
         """
         from ba import _actor as bsactor
         if not isinstance(actor, bsactor.Actor):
-            raise Exception('non-actor passed to _retain_actor')
+            raise TypeError('non-actor passed to retain_actor')
         if (self.has_transitioned_in()
                 and _ba.time() - self._last_prune_dead_actors_time > 10.0):
             print_error('it looks like nodes/actors are not'
@@ -356,7 +356,7 @@ class Activity(DependencyComponent, Generic[PlayerType, TeamType]):
         """
         from ba import _actor as bsactor
         if not isinstance(actor, bsactor.Actor):
-            raise Exception('non-actor passed to _add_actor_weak_ref')
+            raise TypeError('non-actor passed to add_actor_weak_ref')
         if (self.has_transitioned_in()
                 and _ba.time() - self._last_prune_dead_actors_time > 10.0):
             print_error('it looks like nodes/actors are '

--- a/assets/src/ba_data/python/ba/_app.py
+++ b/assets/src/ba_data/python/ba/_app.py
@@ -729,7 +729,7 @@ class App:
         if args is None:
             args = {}
         if game == '':
-            raise Exception('empty game name')
+            raise ValueError('empty game name')
         campaignname, levelname = game.split(':')
         campaign = get_campaign(campaignname)
         levels = campaign.get_levels()

--- a/assets/src/ba_data/python/ba/_campaign.py
+++ b/assets/src/ba_data/python/ba/_campaign.py
@@ -78,9 +78,9 @@ class Campaign:
         for level in self._levels:
             if level.name == name:
                 return level
-        raise _error.NotFoundError(
-            "Level '" + name + "' not found in campaign '" +
-            self.name + "'")
+        raise _error.NotFoundError("Level '" + name +
+                                   "' not found in campaign '" + self.name +
+                                   "'")
 
     def reset(self) -> None:
         """Reset state for the Campaign."""
@@ -100,7 +100,7 @@ class Campaign:
         """Return the live config dict for this campaign."""
         val: Dict[str, Any] = (_ba.app.config.setdefault('Campaigns',
                                                          {}).setdefault(
-            self._name, {}))
+                                                             self._name, {}))
         assert isinstance(val, dict)
         return val
 

--- a/assets/src/ba_data/python/ba/_campaign.py
+++ b/assets/src/ba_data/python/ba/_campaign.py
@@ -64,7 +64,7 @@ class Campaign:
     def add_level(self, level: ba.Level) -> None:
         """Adds a ba.Level to the Campaign."""
         if level.get_campaign() is not None:
-            raise Exception('level already belongs to a campaign')
+            raise RuntimeError('level already belongs to a campaign')
         level.set_campaign(self, len(self._levels))
         self._levels.append(level)
 
@@ -73,12 +73,14 @@ class Campaign:
         return self._levels
 
     def get_level(self, name: str) -> ba.Level:
+        from ba import _error
         """Return a contained ba.Level by name."""
         for level in self._levels:
             if level.name == name:
                 return level
-        raise Exception("Level '" + name + "' not found in campaign '" +
-                        self.name + "'")
+        raise _error.NotFoundError(
+            "Level '" + name + "' not found in campaign '" +
+            self.name + "'")
 
     def reset(self) -> None:
         """Reset state for the Campaign."""
@@ -98,7 +100,7 @@ class Campaign:
         """Return the live config dict for this campaign."""
         val: Dict[str, Any] = (_ba.app.config.setdefault('Campaigns',
                                                          {}).setdefault(
-                                                             self._name, {}))
+            self._name, {}))
         assert isinstance(val, dict)
         return val
 

--- a/assets/src/ba_data/python/ba/_campaign.py
+++ b/assets/src/ba_data/python/ba/_campaign.py
@@ -73,8 +73,8 @@ class Campaign:
         return self._levels
 
     def get_level(self, name: str) -> ba.Level:
-        from ba import _error
         """Return a contained ba.Level by name."""
+        from ba import _error
         for level in self._levels:
             if level.name == name:
                 return level

--- a/assets/src/ba_data/python/ba/_coopsession.py
+++ b/assets/src/ba_data/python/ba/_coopsession.py
@@ -292,7 +292,7 @@ class CoopSession(Session):
                     and self.campaign_state['level'] == 'Onslaught Training'
                     and not app.kiosk_mode):
                 if self._tutorial_activity is None:
-                    raise Exception('tutorial not preloaded properly')
+                    raise RuntimeError('tutorial not preloaded properly')
                 self.set_activity(self._tutorial_activity)
                 self._tutorial_activity = None
                 self._ran_tutorial_activity = True

--- a/assets/src/ba_data/python/ba/_dependency.py
+++ b/assets/src/ba_data/python/ba/_dependency.py
@@ -283,7 +283,7 @@ class DependencySet(Generic[T]):
 
         # Watch for wacky infinite dep loops.
         if recursion > 10:
-            raise Exception('Max recursion reached')
+            raise RecursionError('Max recursion reached')
 
         hashval = dep.get_hash()
 

--- a/assets/src/ba_data/python/ba/_error.py
+++ b/assets/src/ba_data/python/ba/_error.py
@@ -140,7 +140,7 @@ def print_exception(*args: Any, **keywds: Any) -> None:
     if keywds:
         allowed_keywds = ['once']
         if any(keywd not in allowed_keywds for keywd in keywds):
-            raise Exception('invalid keyword(s)')
+            raise TypeError('invalid keyword(s)')
     try:
         # If we're only printing once and already have, bail.
         if keywds.get('once', False):

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -693,7 +693,7 @@ class GameActivity(Activity[PlayerType, TeamType]):
         else:
             sb_desc_l = sb_desc_in
         if not isinstance(sb_desc_l[0], str):
-            raise Exception('Invalid format for instance description')
+            raise TypeError('Invalid format for instance description')
 
         is_empty = (sb_desc_l[0] == '')
         subs = []
@@ -781,7 +781,7 @@ class GameActivity(Activity[PlayerType, TeamType]):
         else:
             desc_l = desc_in
         if not isinstance(desc_l[0], str):
-            raise Exception('Invalid format for instance description')
+            raise TypeError('Invalid format for instance description')
         subs = []
         for i in range(len(desc_l) - 1):
             subs.append(('${ARG' + str(i + 1) + '}', str(desc_l[i + 1])))

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -965,7 +965,7 @@ class GameActivity(Activity[PlayerType, TeamType]):
         The default implementation simply calls spawn_player_spaz().
         """
         if not player:
-            raise Exception('spawn_player() called for nonexistent player')
+            raise TypeError('spawn_player() called for nonexistent player')
 
         return self.spawn_player_spaz(player)
 

--- a/assets/src/ba_data/python/ba/_gameutils.py
+++ b/assets/src/ba_data/python/ba/_gameutils.py
@@ -137,7 +137,7 @@ def sharedobj(name: str) -> Any:
                                       True), ('modify_part_collision',
                                               'friction', 0.0)))
         else:
-            raise Exception(
+            raise ValueError(
                 "unrecognized shared object (activity context): '" + name +
                 "'")
     else:
@@ -156,10 +156,10 @@ def sharedobj(name: str) -> Any:
             if name == 'globals':
                 obj = _ba.newnode('sessionglobals')
             else:
-                raise Exception('unrecognized shared object '
-                                "(session context): '" + name + "'")
+                raise ValueError('unrecognized shared object '
+                                 "(session context): '" + name + "'")
         else:
-            raise Exception('no current activity or session context')
+            raise RuntimeError('no current activity or session context')
 
     # Ok, got a shiny new shared obj; store it for quick access next time.
     sharedobjs[name] = obj
@@ -208,7 +208,7 @@ def animate(node: ba.Node,
     elif timeformat is TimeFormat.MILLISECONDS:
         mult = 1
     else:
-        raise Exception(f'invalid timeformat value: {timeformat}')
+        raise ValueError(f'invalid timeformat value: {timeformat}')
 
     curve.times = [int(mult * time) for time, val in items]
     curve.offset = _ba.time(timeformat=TimeFormat.MILLISECONDS) + int(
@@ -269,7 +269,7 @@ def animate_array(node: ba.Node,
     elif timeformat is TimeFormat.MILLISECONDS:
         mult = 1
     else:
-        raise Exception('invalid timeformat value: "' + str(timeformat) + '"')
+        raise ValueError('invalid timeformat value: "' + str(timeformat) + '"')
 
     for i in range(size):
         curve = _ba.newnode('animcurve',
@@ -390,7 +390,7 @@ def timestring(timeval: float,
     elif timeformat is TimeFormat.MILLISECONDS:
         pass
     else:
-        raise Exception(f'invalid timeformat: {timeformat}')
+        raise ValueError(f'invalid timeformat: {timeformat}')
     if not isinstance(timeval, int):
         timeval = int(timeval)
     bits = []

--- a/assets/src/ba_data/python/ba/_lang.py
+++ b/assets/src/ba_data/python/ba/_lang.py
@@ -111,7 +111,7 @@ class Lstr:
         """
         # pylint: disable=too-many-branches
         if args:
-            raise Exception('Lstr accepts only keyword arguments')
+            raise TypeError('Lstr accepts only keyword arguments')
 
         # Basically just store the exact args they passed.
         # However if they passed any Lstr values for subs,
@@ -120,7 +120,7 @@ class Lstr:
         our_type = type(self)
 
         if isinstance(self.args.get('value'), our_type):
-            raise Exception("'value' must be a regular string; not an Lstr")
+            raise TypeError("'value' must be a regular string; not an Lstr")
 
         if 'subs' in self.args:
             subs_new = []
@@ -301,7 +301,7 @@ def _add_to_attr_dict(dst: AttrDict, src: Dict) -> None:
             _add_to_attr_dict(dst_dict, value)
         else:
             if not isinstance(value, (float, int, bool, str, str, type(None))):
-                raise Exception("invalid value type for res '" + key + "': " +
+                raise TypeError("invalid value type for res '" + key + "': " +
                                 str(type(value)))
             dst[key] = value
 
@@ -401,9 +401,10 @@ def get_resource(resource: str,
         # Ok, looks like we couldn't find our main or fallback resource
         # anywhere. Now if we've been given a fallback value, return it;
         # otherwise fail.
+        from ba import _error
         if fallback_value is not None:
             return fallback_value
-        raise Exception("resource not found: '" + resource + "'")
+        raise _error.NotFoundError("resource not found: '" + resource + "'")
 
 
 def translate(category: str,
@@ -466,5 +467,5 @@ def is_custom_unicode_char(char: str) -> bool:
     """Return whether a char is in the custom unicode range we use."""
     assert isinstance(char, str)
     if len(char) != 1:
-        raise Exception('Invalid Input; must be length 1')
+        raise ValueError('Invalid Input; must be length 1')
     return 0xE000 <= ord(char) <= 0xF8FF

--- a/assets/src/ba_data/python/ba/_level.py
+++ b/assets/src/ba_data/python/ba/_level.py
@@ -169,7 +169,7 @@ class Level:
         can be modified in place."""
         campaign = self.get_campaign()
         if campaign is None:
-            raise Exception('level is not in a campaign')
+            raise TypeError('level is not in a campaign')
         campaign_config = campaign.get_config_dict()
         val: Dict[str,
                   Any] = campaign_config.setdefault(self._name, {

--- a/assets/src/ba_data/python/ba/_lobby.py
+++ b/assets/src/ba_data/python/ba/_lobby.py
@@ -353,7 +353,8 @@ class Chooser:
         """The chooser's ba.Lobby."""
         lobby = self._lobby()
         if lobby is None:
-            raise Exception('Lobby does not exist.')
+            from ba import _error
+            raise _error.NotFoundError('Lobby does not exist.')
         return lobby
 
     def get_lobby(self) -> Optional[ba.Lobby]:

--- a/assets/src/ba_data/python/ba/_map.py
+++ b/assets/src/ba_data/python/ba/_map.py
@@ -144,7 +144,8 @@ def get_map_class(name: str) -> Type[ba.Map]:
     try:
         return _ba.app.maps[name]
     except Exception:
-        raise Exception("Map not found: '" + name + "'")
+        from ba import _error
+        raise _error.NotFoundError("Map not found: '" + name + "'")
 
 
 class Map(Actor):
@@ -218,9 +219,11 @@ class Map(Actor):
         try:
             self.preloaddata = _ba.getactivity().preloads[type(self)]
         except Exception:
-            raise Exception('Preload data not found for ' + str(type(self)) +
-                            '; make sure to call the type\'s preload()'
-                            ' staticmethod in the activity constructor')
+            from ba import _error
+            raise _error.NotFoundError(
+                'Preload data not found for ' + str(type(self)) +
+                '; make sure to call the type\'s preload()'
+                ' staticmethod in the activity constructor')
 
         # Set various globals.
         gnode = _gameutils.sharedobj('globals')
@@ -339,7 +342,7 @@ class Map(Actor):
                     point_list.append(pts)
                 else:
                     if len(pts) != 3:
-                        raise Exception('invalid point')
+                        raise ValueError('invalid point')
                     point_list.append(pts + (0, 0, 0))
                 i += 1
         return point_list
@@ -354,7 +357,7 @@ class Map(Actor):
         return pnt
 
     def get_ffa_start_position(
-            self, players: Sequence[ba.Player]) -> Sequence[float]:
+        self, players: Sequence[ba.Player]) -> Sequence[float]:
         """Return a random starting position in one of the FFA spawn areas.
 
         If a list of ba.Players is provided; the returned points will be
@@ -428,5 +431,5 @@ class Map(Actor):
 def register_map(maptype: Type[Map]) -> None:
     """Register a map class with the game."""
     if maptype.name in _ba.app.maps:
-        raise Exception('map "' + maptype.name + '" already registered')
+        raise RuntimeError('map "' + maptype.name + '" already registered')
     _ba.app.maps[maptype.name] = maptype

--- a/assets/src/ba_data/python/ba/_map.py
+++ b/assets/src/ba_data/python/ba/_map.py
@@ -365,11 +365,12 @@ class Map(Actor):
         player_pts = []
         for player in players:
             try:
-                if player.node:
+                if player and player.node:
                     pnt = _ba.Vec3(player.node.position)
                     player_pts.append(pnt)
-            except Exception as exc:
-                print('EXC in get_ffa_start_position:', exc)
+            except Exception:
+                from ba import _error
+                _error.print_exception()
 
         def _getpt() -> Sequence[float]:
             point = self.ffa_spawn_points[self._next_ffa_start_index]

--- a/assets/src/ba_data/python/ba/_map.py
+++ b/assets/src/ba_data/python/ba/_map.py
@@ -357,7 +357,7 @@ class Map(Actor):
         return pnt
 
     def get_ffa_start_position(
-        self, players: Sequence[ba.Player]) -> Sequence[float]:
+            self, players: Sequence[ba.Player]) -> Sequence[float]:
         """Return a random starting position in one of the FFA spawn areas.
 
         If a list of ba.Players is provided; the returned points will be

--- a/assets/src/ba_data/python/ba/_meta.py
+++ b/assets/src/ba_data/python/ba/_meta.py
@@ -326,7 +326,7 @@ def get_scan_results() -> ScanResults:
         while app.metascan is None:
             time.sleep(0.05)
             if time.time() - starttime > 10.0:
-                raise Exception('timeout waiting for meta scan to complete.')
+                raise TimeoutError('timeout waiting for meta scan to complete.')
     return app.metascan
 
 

--- a/assets/src/ba_data/python/ba/_meta.py
+++ b/assets/src/ba_data/python/ba/_meta.py
@@ -326,7 +326,8 @@ def get_scan_results() -> ScanResults:
         while app.metascan is None:
             time.sleep(0.05)
             if time.time() - starttime > 10.0:
-                raise TimeoutError('timeout waiting for meta scan to complete.')
+                raise TimeoutError(
+                    'timeout waiting for meta scan to complete.')
     return app.metascan
 
 

--- a/assets/src/ba_data/python/ba/_music.py
+++ b/assets/src/ba_data/python/ba/_music.py
@@ -191,7 +191,7 @@ class MusicController:
         """Returns the system music player, instantiating if necessary."""
         if self._music_player is None:
             if self._music_player_type is None:
-                raise Exception('no music player type set')
+                raise TypeError('no music player type set')
             self._music_player = self._music_player_type()
         return self._music_player
 
@@ -248,20 +248,21 @@ class MusicController:
                   and isinstance(entry['name'], str)):
                 entry_type = entry['type']
             else:
-                raise Exception('invalid soundtrack entry: ' + str(entry) +
+                raise TypeError('invalid soundtrack entry: ' + str(entry) +
                                 ' (type ' + str(type(entry)) + ')')
             if self.supports_soundtrack_entry_type(entry_type):
                 return entry_type
-            raise Exception('invalid soundtrack entry:' + str(entry))
-        except Exception as exc:
-            print('EXC on get_soundtrack_entry_type', exc)
+            raise ValueError('invalid soundtrack entry:' + str(entry))
+        except Exception:
+            from ba import _error
+            _error.print_exception()
             return 'default'
 
     def get_soundtrack_entry_name(self, entry: Any) -> str:
         """Given a soundtrack entry, returns its name."""
         try:
             if entry is None:
-                raise Exception('entry is None')
+                raise TypeError('entry is None')
 
             # Simple string denotes an iTunesPlaylist name (legacy entry).
             if isinstance(entry, str):
@@ -272,7 +273,7 @@ class MusicController:
                     and isinstance(entry['type'], str) and 'name' in entry
                     and isinstance(entry['name'], str)):
                 return entry['name']
-            raise Exception('invalid soundtrack entry:' + str(entry))
+            raise ValueError('invalid soundtrack entry:' + str(entry))
         except Exception:
             from ba import _error
             _error.print_exception()

--- a/assets/src/ba_data/python/ba/_netutils.py
+++ b/assets/src/ba_data/python/ba/_netutils.py
@@ -56,7 +56,7 @@ def get_ip_address_type(addr: str) -> socket.AddressFamily:
         except OSError:
             pass
     if socket_type is None:
-        raise Exception('addr seems to be neither v4 or v6: ' + str(addr))
+        raise ValueError('addr seems to be neither v4 or v6: ' + str(addr))
     return socket_type
 
 
@@ -76,7 +76,7 @@ class ServerCallThread(threading.Thread):
         self._request = request
         self._request_type = request_type
         if not isinstance(response_type, ServerResponseType):
-            raise Exception(f'Invalid response type: {response_type}')
+            raise TypeError(f'Invalid response type: {response_type}')
         self._response_type = response_type
         self._data = {} if data is None else copy.deepcopy(data)
         self._callback: Optional[ServerCallbackType] = callback
@@ -128,7 +128,7 @@ class ServerCallThread(threading.Thread):
                         parse.urlencode(self._data).encode(),
                         {'User-Agent': _ba.app.user_agent_string}))
             else:
-                raise Exception('Invalid request_type: ' + self._request_type)
+                raise TypeError('Invalid request_type: ' + self._request_type)
 
             # If html request failed.
             if response.getcode() != 200:
@@ -144,7 +144,7 @@ class ServerCallThread(threading.Thread):
                     raw_data_s = raw_data.decode()
                     response_data = json.loads(raw_data_s)
             else:
-                raise Exception(f'invalid responsetype: {self._response_type}')
+                raise TypeError(f'invalid responsetype: {self._response_type}')
         except (urllib.error.URLError, ConnectionError):
             # Server rejected us, broken pipe, etc.  It happens. Ignoring.
             response_data = None

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -181,7 +181,7 @@ class Player(Generic[TeamType]):
         self._sessionplayer.reset_input()
 
     def __bool__(self) -> bool:
-        return self._sessionplayer.exists()
+        return self.exists()
 
 
 def playercast(totype: Type[PlayerType], player: ba.Player) -> PlayerType:

--- a/assets/src/ba_data/python/ba/_playlist.py
+++ b/assets/src/ba_data/python/ba/_playlist.py
@@ -80,7 +80,7 @@ def filter_playlist(playlist: PlaylistType,
         # the actual game class. add successful ones to our initial list
         # to present to the user.
         if not isinstance(entry['type'], str):
-            raise Exception('invalid entry format')
+            raise TypeError('invalid entry format')
         try:
             # Do some type filters for backwards compat.
             if entry['type'] in ('Assault.AssaultGame',

--- a/assets/src/ba_data/python/ba/_store.py
+++ b/assets/src/ba_data/python/ba/_store.py
@@ -56,7 +56,7 @@ def get_store_item_name_translated(item_name: str) -> ba.Lstr:
         return gametype.get_display_string()
     if item_name.startswith('icons.'):
         return _lang.Lstr(resource='editProfileWindow.iconText')
-    raise Exception('unrecognized item: ' + item_name)
+    raise ValueError('unrecognized item: ' + item_name)
 
 
 def get_store_item_display_size(item_name: str) -> Tuple[float, float]:

--- a/assets/src/ba_data/python/ba/ui/__init__.py
+++ b/assets/src/ba_data/python/ba/ui/__init__.py
@@ -127,7 +127,7 @@ class UIEntry:
         if self._name == 'mainmenu':
             from bastd.ui import mainmenu
             return cast(Type[UILocation], mainmenu.MainMenuWindow)
-        raise Exception('unknown ui class ' + str(self._name))
+        raise ValueError('unknown ui class ' + str(self._name))
 
 
 class UIController:
@@ -192,7 +192,7 @@ def uicleanupcheck(obj: Any, widget: ba.Widget) -> None:
     if DEBUG_UI_CLEANUP_CHECKS:
         print(f'adding uicleanup to {obj}')
     if not isinstance(widget, _ba.Widget):
-        raise Exception('widget arg is not a ba.Widget')
+        raise TypeError('widget arg is not a ba.Widget')
 
     def foobar() -> None:
         """Just testing."""

--- a/assets/src/ba_data/python/bastd/activity/coopscore.py
+++ b/assets/src/ba_data/python/bastd/activity/coopscore.py
@@ -172,7 +172,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         self._game_name_str = self._campaign.name + ':' + self._level_name
         self._game_config_str = str(len(
             self._player_info)) + 'p' + self._campaign.get_level(
-            self._level_name).get_score_version_string().replace(' ', '_')
+                self._level_name).get_score_version_string().replace(' ', '_')
 
         # If game-center/etc scores are available we show our friends'
         # scores. Otherwise we show our local high scores.
@@ -265,7 +265,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         # If we didn't just complete this level but are choosing to play the
         # next one, set it as current (this won't happen otherwise).
         if (self._is_complete and self._is_more_levels
-            and not self._newly_complete):
+                and not self._newly_complete):
             assert self._next_level_name is not None
             self._campaign.set_selected_level(self._next_level_name)
         ba.containerwidget(edit=self._root_ui, transition='out_left')
@@ -387,8 +387,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                 label=ba.Lstr(resource='tournamentStandingsText')
                 if self.session.tournament_id is not None else ba.Lstr(
                     resource='worldsBestScoresText') if self._score_type
-                                                        == 'points' else ba.Lstr(
-                    resource='worldsBestTimesText'),
+                == 'points' else ba.Lstr(resource='worldsBestTimesText'),
                 autoselect=True,
                 on_activate_call=ba.WeakCall(self._ui_worlds_best),
                 transition_delay=delay + 1.9,
@@ -549,7 +548,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         ba.timer(1.0, ba.WeakCall(self.request_ui))
 
         if (self._is_complete and self._victory and self._is_more_levels
-            and not ba.app.kiosk_mode):
+                and not ba.app.kiosk_mode):
             Text(ba.Lstr(value='${A}:\n',
                          subs=[('${A}', ba.Lstr(resource='levelUnlockedText'))
                                ]) if self._newly_complete else
@@ -647,11 +646,11 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                 transition_delay=2.0)
         self._score_loading_status = Text(ba.Lstr(
             value='${A}...', subs=[('${A}', ba.Lstr(resource='loadingText'))]),
-            position=(280, 150 + 30),
-            color=(1, 1, 1, 0.4),
-            transition=Text.Transition.FADE_IN,
-            scale=0.7,
-            transition_delay=2.0)
+                                          position=(280, 150 + 30),
+                                          color=(1, 1, 1, 0.4),
+                                          transition=Text.Transition.FADE_IN,
+                                          scale=0.7,
+                                          transition_delay=2.0)
 
         if self._score is not None:
             ba.timer(0.4, ba.WeakCall(self._play_drumroll))
@@ -728,9 +727,8 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         v_offs = 40
         txt = Text(ba.Lstr(resource='tournamentStandingsText')
                    if self.session.tournament_id is not None else ba.Lstr(
-            resource='worldsBestScoresText') if self._score_type
-                                                == 'points' else ba.Lstr(
-            resource='worldsBestTimesText'),
+                       resource='worldsBestScoresText') if self._score_type
+                   == 'points' else ba.Lstr(resource='worldsBestTimesText'),
                    maxwidth=210,
                    position=(ts_h_offs - 10, ts_height / 2 + 25 + v_offs + 20),
                    transition=Text.Transition.IN_LEFT,
@@ -766,8 +764,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
             ts_h_offs = -480
             v_offs = 40
             Text(ba.Lstr(resource='yourBestScoresText') if self._score_type
-                                                           == 'points' else ba.Lstr(
-                resource='yourBestTimesText'),
+                 == 'points' else ba.Lstr(resource='yourBestTimesText'),
                  maxwidth=210,
                  position=(ts_h_offs - 10, ts_height / 2 + 25 + v_offs + 20),
                  transition=Text.Transition.IN_RIGHT,
@@ -1399,12 +1396,12 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                            str(int(self._show_info['results']['rank']))),
                           ('${ALL}', str(self._show_info['results']['total']))
                           ]),
-                    position=(0, -155 if self._newly_complete else -145),
-                    color=(1, 1, 1, 0.7),
-                    h_align=Text.HAlign.CENTER,
-                    transition=Text.Transition.FADE_IN,
-                    scale=0.55,
-                    transition_delay=1.0).autoretain()
+                     position=(0, -155 if self._newly_complete else -145),
+                     color=(1, 1, 1, 0.7),
+                     h_align=Text.HAlign.CENTER,
+                     transition=Text.Transition.FADE_IN,
+                     scale=0.55,
+                     transition_delay=1.0).autoretain()
 
             new_best = (best_rank > self._old_best_rank and best_rank > 0.0)
             was_string = ba.Lstr(value=' ${A}',

--- a/assets/src/ba_data/python/bastd/activity/coopscore.py
+++ b/assets/src/ba_data/python/bastd/activity/coopscore.py
@@ -149,8 +149,8 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         self._score_order: str
         if 'score_order' in settings:
             if not settings['score_order'] in ['increasing', 'decreasing']:
-                raise Exception('Invalid score order: ' +
-                                settings['score_order'])
+                raise ValueError('Invalid score order: ' +
+                                 settings['score_order'])
             self._score_order = settings['score_order']
         else:
             self._score_order = 'increasing'
@@ -159,8 +159,8 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         self._score_type: str
         if 'score_type' in settings:
             if not settings['score_type'] in ['points', 'time']:
-                raise Exception('Invalid score type: ' +
-                                settings['score_type'])
+                raise ValueError('Invalid score type: ' +
+                                 settings['score_type'])
             self._score_type = settings['score_type']
         else:
             self._score_type = 'points'
@@ -172,7 +172,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         self._game_name_str = self._campaign.name + ':' + self._level_name
         self._game_config_str = str(len(
             self._player_info)) + 'p' + self._campaign.get_level(
-                self._level_name).get_score_version_string().replace(' ', '_')
+            self._level_name).get_score_version_string().replace(' ', '_')
 
         # If game-center/etc scores are available we show our friends'
         # scores. Otherwise we show our local high scores.
@@ -265,7 +265,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         # If we didn't just complete this level but are choosing to play the
         # next one, set it as current (this won't happen otherwise).
         if (self._is_complete and self._is_more_levels
-                and not self._newly_complete):
+            and not self._newly_complete):
             assert self._next_level_name is not None
             self._campaign.set_selected_level(self._next_level_name)
         ba.containerwidget(edit=self._root_ui, transition='out_left')
@@ -387,7 +387,8 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                 label=ba.Lstr(resource='tournamentStandingsText')
                 if self.session.tournament_id is not None else ba.Lstr(
                     resource='worldsBestScoresText') if self._score_type
-                == 'points' else ba.Lstr(resource='worldsBestTimesText'),
+                                                        == 'points' else ba.Lstr(
+                    resource='worldsBestTimesText'),
                 autoselect=True,
                 on_activate_call=ba.WeakCall(self._ui_worlds_best),
                 transition_delay=delay + 1.9,
@@ -548,7 +549,7 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         ba.timer(1.0, ba.WeakCall(self.request_ui))
 
         if (self._is_complete and self._victory and self._is_more_levels
-                and not ba.app.kiosk_mode):
+            and not ba.app.kiosk_mode):
             Text(ba.Lstr(value='${A}:\n',
                          subs=[('${A}', ba.Lstr(resource='levelUnlockedText'))
                                ]) if self._newly_complete else
@@ -646,11 +647,11 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                 transition_delay=2.0)
         self._score_loading_status = Text(ba.Lstr(
             value='${A}...', subs=[('${A}', ba.Lstr(resource='loadingText'))]),
-                                          position=(280, 150 + 30),
-                                          color=(1, 1, 1, 0.4),
-                                          transition=Text.Transition.FADE_IN,
-                                          scale=0.7,
-                                          transition_delay=2.0)
+            position=(280, 150 + 30),
+            color=(1, 1, 1, 0.4),
+            transition=Text.Transition.FADE_IN,
+            scale=0.7,
+            transition_delay=2.0)
 
         if self._score is not None:
             ba.timer(0.4, ba.WeakCall(self._play_drumroll))
@@ -727,8 +728,9 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
         v_offs = 40
         txt = Text(ba.Lstr(resource='tournamentStandingsText')
                    if self.session.tournament_id is not None else ba.Lstr(
-                       resource='worldsBestScoresText') if self._score_type
-                   == 'points' else ba.Lstr(resource='worldsBestTimesText'),
+            resource='worldsBestScoresText') if self._score_type
+                                                == 'points' else ba.Lstr(
+            resource='worldsBestTimesText'),
                    maxwidth=210,
                    position=(ts_h_offs - 10, ts_height / 2 + 25 + v_offs + 20),
                    transition=Text.Transition.IN_LEFT,
@@ -764,7 +766,8 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
             ts_h_offs = -480
             v_offs = 40
             Text(ba.Lstr(resource='yourBestScoresText') if self._score_type
-                 == 'points' else ba.Lstr(resource='yourBestTimesText'),
+                                                           == 'points' else ba.Lstr(
+                resource='yourBestTimesText'),
                  maxwidth=210,
                  position=(ts_h_offs - 10, ts_height / 2 + 25 + v_offs + 20),
                  transition=Text.Transition.IN_RIGHT,
@@ -1396,12 +1399,12 @@ class CoopScoreScreen(ba.Activity[ba.Player, ba.Team]):
                            str(int(self._show_info['results']['rank']))),
                           ('${ALL}', str(self._show_info['results']['total']))
                           ]),
-                     position=(0, -155 if self._newly_complete else -145),
-                     color=(1, 1, 1, 0.7),
-                     h_align=Text.HAlign.CENTER,
-                     transition=Text.Transition.FADE_IN,
-                     scale=0.55,
-                     transition_delay=1.0).autoretain()
+                    position=(0, -155 if self._newly_complete else -145),
+                    color=(1, 1, 1, 0.7),
+                    h_align=Text.HAlign.CENTER,
+                    transition=Text.Transition.FADE_IN,
+                    scale=0.55,
+                    transition_delay=1.0).autoretain()
 
             new_best = (best_rank > self._old_best_rank and best_rank > 0.0)
             was_string = ba.Lstr(value=' ${A}',

--- a/assets/src/ba_data/python/bastd/actor/bomb.py
+++ b/assets/src/ba_data/python/bastd/actor/bomb.py
@@ -665,7 +665,7 @@ class Bomb(ba.Actor):
 
         if bomb_type not in ('ice', 'impact', 'land_mine', 'normal', 'sticky',
                              'tnt'):
-            raise Exception('invalid bomb type: ' + bomb_type)
+            raise ValueError('invalid bomb type: ' + bomb_type)
         self.bomb_type = bomb_type
 
         self._exploded = False

--- a/assets/src/ba_data/python/bastd/actor/onscreentimer.py
+++ b/assets/src/ba_data/python/bastd/actor/onscreentimer.py
@@ -95,7 +95,7 @@ class OnScreenTimer(ba.Actor):
                 assert isinstance(endtime, int)
                 endtime_ms = endtime
             else:
-                raise Exception(f'invalid timeformat: {timeformat}')
+                raise ValueError(f'invalid timeformat: {timeformat}')
 
             self.inputnode.timemax = endtime_ms - self._starttime
 
@@ -119,7 +119,7 @@ class OnScreenTimer(ba.Actor):
             return 0.001 * val_ms
         if timeformat is ba.TimeFormat.MILLISECONDS:
             return val_ms
-        raise Exception(f'invalid timeformat: {timeformat}')
+        raise ValueError(f'invalid timeformat: {timeformat}')
 
     def handlemessage(self, msg: Any) -> Any:
         # if we're asked to die, just kill our node/timer

--- a/assets/src/ba_data/python/bastd/actor/powerupbox.py
+++ b/assets/src/ba_data/python/bastd/actor/powerupbox.py
@@ -187,7 +187,7 @@ def get_factory() -> PowerupBoxFactory:
     """Return a shared ba.PowerupBoxFactory object, creating if necessary."""
     activity = ba.getactivity()
     if activity is None:
-        raise Exception('no current activity')
+        raise RuntimeError('no current activity')
     try:
         # FIXME: et better way to store stuff with activity
         # pylint: disable=protected-access
@@ -252,10 +252,10 @@ class PowerupBox(ba.Actor):
         elif poweruptype == 'curse':
             tex = factory.tex_curse
         else:
-            raise Exception('invalid poweruptype: ' + str(poweruptype))
+            raise ValueError('invalid poweruptype: ' + str(poweruptype))
 
         if len(position) != 3:
-            raise Exception('expected 3 floats for position')
+            raise ValueError('expected 3 floats for position')
 
         self.node = ba.newnode(
             'prop',

--- a/assets/src/ba_data/python/bastd/actor/spaz.py
+++ b/assets/src/ba_data/python/bastd/actor/spaz.py
@@ -1384,7 +1384,7 @@ class Spaz(ba.Actor):
             return bomb_factory.tex_ice_bombs
         if self.bomb_type == 'impact':
             return bomb_factory.tex_impact_bombs
-        raise Exception()
+        raise ValueError('invalid bomb type')
 
     def _flash_billboard(self, tex: ba.Texture) -> None:
         assert self.node

--- a/assets/src/ba_data/python/bastd/game/runaround.py
+++ b/assets/src/ba_data/python/bastd/game/runaround.py
@@ -526,7 +526,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                 position=pos,
                 poweruptype=powerupbox.get_factory().get_random_powerup_type(
                     excludetypes=self._exclude_powerups +
-                                 extra_excludes)).autoretain()
+                    extra_excludes)).autoretain()
 
     def end_game(self) -> None:
 
@@ -574,7 +574,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
 
         # If we have no living bots, go to the next wave.
         if (self._can_end_wave and not self._bots.have_living_bots()
-            and not self._game_over and self._lives > 0):
+                and not self._game_over and self._lives > 0):
 
             self._can_end_wave = False
             self._time_bonus_timer = None
@@ -653,9 +653,9 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
             value='+${A} ${B}',
             subs=[('${A}', str(bonus)),
                   ('${B}', ba.Lstr(resource='completionBonusText'))]),
-            color=(0.7, 0.7, 1.0, 1),
-            scale=1.6,
-            position=(0, 1.5, -1)).autoretain()
+                            color=(0.7, 0.7, 1.0, 1),
+                            scale=1.6,
+                            position=(0, 1.5, -1)).autoretain()
         self._score += bonus
         self._update_scores()
 
@@ -839,7 +839,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                     len(defender_types))]
                 defender1 = defender2 = None
                 if ((group == 0) or (group == 1 and level > 3)
-                    or (group == 2 and level > 5)):
+                        or (group == 2 and level > 5)):
                     if random.random() < min(0.75, (level - 1) * 0.11):
                         this_target_point_s, defender1 = _add_defender(
                             defender_type1, 'bottom_left')
@@ -1109,7 +1109,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
             return True
         if ((ba.is_point_in_box(pos, boxes['b8'])
              and not ba.is_point_in_box(pos, boxes['b9']))
-            or pos == (0.0, 0.0, 0.0)):
+                or pos == (0.0, 0.0, 0.0)):
             # Default to walking right if we're still in the walking area.
             bot.node.move_left_right = speed
             bot.node.move_up_down = 0

--- a/assets/src/ba_data/python/bastd/game/runaround.py
+++ b/assets/src/ba_data/python/bastd/game/runaround.py
@@ -224,7 +224,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                 ]},
                 {'entries': [
                     {'type': spazbot.ChargerBotProShielded if hard
-                     else spazbot.ChargerBot, 'path': 1},
+                    else spazbot.ChargerBot, 'path': 1},
                     {'type': spazbot.BrawlerBot, 'path': 2} if hard else None,
                     {'type': spazbot.BrawlerBot, 'path': 2},
                     {'type': spazbot.BrawlerBot, 'path': 2},
@@ -273,7 +273,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                     {'type': spazbot.TriggerBot, 'path': 2},
                     {'type': spazbot.TriggerBot, 'path': 3},
                     {'type': spazbot.BrawlerBotPro if hard
-                     else spazbot.BrawlerBot, 'point': 'bottom_left'},
+                    else spazbot.BrawlerBot, 'point': 'bottom_left'},
                     {'type': spazbot.BrawlerBotPro, 'point': 'bottom_right'}
                     if player_count > 2 else None,
                 ]},
@@ -312,7 +312,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                 ]},
                 {'entries': [
                     {'type': spazbot.TriggerBotProShielded if hard
-                     else spazbot.TriggerBotPro, 'point': 'bottom_left'},
+                    else spazbot.TriggerBotPro, 'point': 'bottom_left'},
                     {'type': spazbot.TriggerBotProShielded,
                      'point': 'bottom_right'}
                     if hard else None,
@@ -526,7 +526,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                 position=pos,
                 poweruptype=powerupbox.get_factory().get_random_powerup_type(
                     excludetypes=self._exclude_powerups +
-                    extra_excludes)).autoretain()
+                                 extra_excludes)).autoretain()
 
     def end_game(self) -> None:
 
@@ -574,7 +574,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
 
         # If we have no living bots, go to the next wave.
         if (self._can_end_wave and not self._bots.have_living_bots()
-                and not self._game_over and self._lives > 0):
+            and not self._game_over and self._lives > 0):
 
             self._can_end_wave = False
             self._time_bonus_timer = None
@@ -653,9 +653,9 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
             value='+${A} ${B}',
             subs=[('${A}', str(bonus)),
                   ('${B}', ba.Lstr(resource='completionBonusText'))]),
-                            color=(0.7, 0.7, 1.0, 1),
-                            scale=1.6,
-                            position=(0, 1.5, -1)).autoretain()
+            color=(0.7, 0.7, 1.0, 1),
+            scale=1.6,
+            position=(0, 1.5, -1)).autoretain()
         self._score += bonus
         self._update_scores()
 
@@ -839,7 +839,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
                     len(defender_types))]
                 defender1 = defender2 = None
                 if ((group == 0) or (group == 1 and level > 3)
-                        or (group == 2 and level > 5)):
+                    or (group == 2 and level > 5)):
                     if random.random() < min(0.75, (level - 1) * 0.11):
                         this_target_point_s, defender1 = _add_defender(
                             defender_type1, 'bottom_left')
@@ -1109,8 +1109,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
             return True
         if ((ba.is_point_in_box(pos, boxes['b8'])
              and not ba.is_point_in_box(pos, boxes['b9']))
-                or pos == (0.0, 0.0, 0.0)):
-
+            or pos == (0.0, 0.0, 0.0)):
             # Default to walking right if we're still in the walking area.
             bot.node.move_left_right = speed
             bot.node.move_up_down = 0
@@ -1177,7 +1176,7 @@ class RunaroundGame(ba.CoopGameActivity[Player, Team]):
     def _get_bot_speed(self, bot_type: Type[spazbot.SpazBot]) -> float:
         speed = self._bot_speed_map.get(bot_type)
         if speed is None:
-            raise Exception('Invalid bot type to _get_bot_speed(): ' +
+            raise TypeError('Invalid bot type to _get_bot_speed(): ' +
                             str(bot_type))
         return speed
 

--- a/assets/src/ba_data/python/bastd/ui/account/settings.py
+++ b/assets/src/ba_data/python/bastd/ui/account/settings.py
@@ -627,8 +627,8 @@ class AccountSettingsWindow(ba.Window):
             elif account_type == 'Game Circle':
                 account_type_name = ba.Lstr(resource='gameCircleText')
             else:
-                raise ValueError("unknown account type: '" + str(account_type) +
-                                 "'")
+                raise ValueError("unknown account type: '" +
+                                 str(account_type) + "'")
             self._game_service_button = btn = ba.buttonwidget(
                 parent=self._subcontainer,
                 position=((self._sub_width - button_width) * 0.5, v),

--- a/assets/src/ba_data/python/bastd/ui/account/settings.py
+++ b/assets/src/ba_data/python/bastd/ui/account/settings.py
@@ -627,8 +627,8 @@ class AccountSettingsWindow(ba.Window):
             elif account_type == 'Game Circle':
                 account_type_name = ba.Lstr(resource='gameCircleText')
             else:
-                raise Exception("unknown account type: '" + str(account_type) +
-                                "'")
+                raise ValueError("unknown account type: '" + str(account_type) +
+                                 "'")
             self._game_service_button = btn = ba.buttonwidget(
                 parent=self._subcontainer,
                 position=((self._sub_width - button_width) * 0.5, v),
@@ -1105,7 +1105,7 @@ class AccountSettingsWindow(ba.Window):
             elif sel == self._scrollwidget:
                 sel_name = 'Scroll'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError('unrecognized selection')
             ba.app.window_states[self.__class__.__name__] = sel_name
         except Exception:
             ba.print_exception('exception saving state for', self.__class__)

--- a/assets/src/ba_data/python/bastd/ui/colorpicker.py
+++ b/assets/src/ba_data/python/bastd/ui/colorpicker.py
@@ -50,7 +50,7 @@ class ColorPicker(popup.PopupWindow):
 
         c_raw = get_player_colors()
         if len(c_raw) != 16:
-            raise Exception('expected 16 player colors')
+            raise ValueError('expected 16 player colors')
         self.colors = [c_raw[0:4], c_raw[4:8], c_raw[8:12], c_raw[12:16]]
 
         if scale is None:
@@ -189,7 +189,7 @@ class ColorPickerExact(popup.PopupWindow):
         from ba.internal import get_player_colors
         c_raw = get_player_colors()
         if len(c_raw) != 16:
-            raise Exception('expected 16 player colors')
+            raise ValueError('expected 16 player colors')
         self.colors = [c_raw[0:4], c_raw[4:8], c_raw[8:12], c_raw[12:16]]
 
         if scale is None:

--- a/assets/src/ba_data/python/bastd/ui/coop/browser.py
+++ b/assets/src/ba_data/python/bastd/ui/coop/browser.py
@@ -1555,7 +1555,7 @@ class CoopBrowserWindow(ba.Window):
             elif sel == self._scrollwidget:
                 sel_name = 'Scroll'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError('unrecognized selection')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name
             }

--- a/assets/src/ba_data/python/bastd/ui/gather.py
+++ b/assets/src/ba_data/python/bastd/ui/gather.py
@@ -807,11 +807,8 @@ class GatherWindow(ba.Window):
                         color=(1, 0, 0))
                     ba.playsound(ba.getsound('error'))
                     return
-                try:
-                    port = int(cast(str, ba.textwidget(query=port_textwidget)))
-                    if port > 65535 or port < 0:
-                        raise Exception()
-                except Exception:
+                port = int(cast(str, ba.textwidget(query=port_textwidget)))
+                if port > 65535 or port < 0:
                     ba.screenmessage(
                         ba.Lstr(resource='internal.invalidPortErrorText'),
                         color=(1, 0, 0))
@@ -1958,7 +1955,7 @@ class GatherWindow(ba.Window):
             elif sel == self._tab_container:
                 sel_name = 'TabContainer'
             else:
-                raise Exception('unrecognized selection: ' + str(sel))
+                raise ValueError(f'unrecognized selection: \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name,
                 'tab': self._current_tab,

--- a/assets/src/ba_data/python/bastd/ui/mainmenu.py
+++ b/assets/src/ba_data/python/bastd/ui/mainmenu.py
@@ -49,7 +49,7 @@ class MainMenuWindow(ba.Window):
         super().__init__(root_widget=ba.containerwidget(
             transition=transition,
             toolbar_visibility='menu_minimal_no_back' if self.
-            _in_game else 'menu_minimal_no_back'))
+                _in_game else 'menu_minimal_no_back'))
 
         self._is_kiosk = ba.app.kiosk_mode
         self._tdelay = 0.0
@@ -95,7 +95,7 @@ class MainMenuWindow(ba.Window):
                 _ba.get_local_active_input_devices_count()
                 if (((app.on_tv or app.platform == 'mac')
                      and ba.app.config.get('launchCount', 0) <= 1)
-                        or force_test):
+                    or force_test):
 
                     def _check_show_bs_remote_window() -> None:
                         try:
@@ -131,7 +131,7 @@ class MainMenuWindow(ba.Window):
         store_char_tex = self._get_store_char_tex()
         account_state_num = _ba.get_account_state_num()
         if (account_state_num != self._account_state_num
-                or store_char_tex != self._store_char_tex):
+            or store_char_tex != self._store_char_tex):
             self._store_char_tex = store_char_tex
             self._account_state_num = account_state_num
             account_state = self._account_state = (_ba.get_account_state())
@@ -294,8 +294,8 @@ class MainMenuWindow(ba.Window):
                 size=(self._button_width, self._button_height),
                 scale=scale,
                 label=ba.Lstr(resource=self._r +
-                              ('.quitText' if 'Mac' in
-                               ba.app.user_agent_string else '.exitGameText')),
+                                       ('.quitText' if 'Mac' in
+                                                       ba.app.user_agent_string else '.exitGameText')),
                 on_activate_call=self._quit,
                 transition_delay=self._tdelay)
 
@@ -320,8 +320,7 @@ class MainMenuWindow(ba.Window):
             # If we're not in-game, have no quit button, and this is android,
             # we want back presses to quit our activity.
             if (not self._in_game and not self._have_quit_button
-                    and ba.app.platform == 'android'):
-
+                and ba.app.platform == 'android'):
                 def _do_quit() -> None:
                     confirm.QuitWindow(swish=True, back=True)
 
@@ -671,10 +670,10 @@ class MainMenuWindow(ba.Window):
                 custom_menu_entries = session.get_custom_menu_entries()
                 for cme in custom_menu_entries:
                     if (not isinstance(cme, dict) or 'label' not in cme
-                            or not isinstance(cme['label'], (str, ba.Lstr))
-                            or 'call' not in cme or not callable(cme['call'])):
-                        raise Exception('invalid custom menu entry: ' +
-                                        str(cme))
+                        or not isinstance(cme['label'], (str, ba.Lstr))
+                        or 'call' not in cme or not callable(cme['call'])):
+                        raise ValueError('invalid custom menu entry: ' +
+                                         str(cme))
             except Exception:
                 custom_menu_entries = []
                 ba.print_exception('exception getting custom menu entries for',
@@ -757,7 +756,7 @@ class MainMenuWindow(ba.Window):
                             autoselect=self._use_autoselect)
         # Add a 'leave' button if the menu-owner has a player.
         if ((self._input_player or self._connected_to_remote_player)
-                and not self._is_kiosk):
+            and not self._is_kiosk):
             h, v, scale = positions[self._p_index]
             self._p_index += 1
             btn = ba.buttonwidget(parent=self._root_widget,
@@ -770,7 +769,7 @@ class MainMenuWindow(ba.Window):
                                   autoselect=self._use_autoselect)
 
             if (player_name != '' and player_name[0] != '<'
-                    and player_name[-1] != '>'):
+                and player_name[-1] != '>'):
                 txt = ba.Lstr(resource=self._r + '.justPlayerText',
                               subs=[('${NAME}', player_name)])
             else:
@@ -866,7 +865,7 @@ class MainMenuWindow(ba.Window):
         # Select cancel by default; this occasionally gets called by accident
         # in a fit of button mashing and this will help reduce damage.
         confirm.ConfirmWindow(ba.Lstr(resource=self._r +
-                                      '.leavePartyConfirmText'),
+                                               '.leavePartyConfirmText'),
                               self._leave_party,
                               cancel_is_selected=True)
 

--- a/assets/src/ba_data/python/bastd/ui/mainmenu.py
+++ b/assets/src/ba_data/python/bastd/ui/mainmenu.py
@@ -49,7 +49,7 @@ class MainMenuWindow(ba.Window):
         super().__init__(root_widget=ba.containerwidget(
             transition=transition,
             toolbar_visibility='menu_minimal_no_back' if self.
-                _in_game else 'menu_minimal_no_back'))
+            _in_game else 'menu_minimal_no_back'))
 
         self._is_kiosk = ba.app.kiosk_mode
         self._tdelay = 0.0
@@ -95,7 +95,7 @@ class MainMenuWindow(ba.Window):
                 _ba.get_local_active_input_devices_count()
                 if (((app.on_tv or app.platform == 'mac')
                      and ba.app.config.get('launchCount', 0) <= 1)
-                    or force_test):
+                        or force_test):
 
                     def _check_show_bs_remote_window() -> None:
                         try:
@@ -131,7 +131,7 @@ class MainMenuWindow(ba.Window):
         store_char_tex = self._get_store_char_tex()
         account_state_num = _ba.get_account_state_num()
         if (account_state_num != self._account_state_num
-            or store_char_tex != self._store_char_tex):
+                or store_char_tex != self._store_char_tex):
             self._store_char_tex = store_char_tex
             self._account_state_num = account_state_num
             account_state = self._account_state = (_ba.get_account_state())
@@ -294,8 +294,8 @@ class MainMenuWindow(ba.Window):
                 size=(self._button_width, self._button_height),
                 scale=scale,
                 label=ba.Lstr(resource=self._r +
-                                       ('.quitText' if 'Mac' in
-                                                       ba.app.user_agent_string else '.exitGameText')),
+                              ('.quitText' if 'Mac' in
+                               ba.app.user_agent_string else '.exitGameText')),
                 on_activate_call=self._quit,
                 transition_delay=self._tdelay)
 
@@ -320,7 +320,8 @@ class MainMenuWindow(ba.Window):
             # If we're not in-game, have no quit button, and this is android,
             # we want back presses to quit our activity.
             if (not self._in_game and not self._have_quit_button
-                and ba.app.platform == 'android'):
+                    and ba.app.platform == 'android'):
+
                 def _do_quit() -> None:
                     confirm.QuitWindow(swish=True, back=True)
 
@@ -670,8 +671,8 @@ class MainMenuWindow(ba.Window):
                 custom_menu_entries = session.get_custom_menu_entries()
                 for cme in custom_menu_entries:
                     if (not isinstance(cme, dict) or 'label' not in cme
-                        or not isinstance(cme['label'], (str, ba.Lstr))
-                        or 'call' not in cme or not callable(cme['call'])):
+                            or not isinstance(cme['label'], (str, ba.Lstr))
+                            or 'call' not in cme or not callable(cme['call'])):
                         raise ValueError('invalid custom menu entry: ' +
                                          str(cme))
             except Exception:
@@ -756,7 +757,7 @@ class MainMenuWindow(ba.Window):
                             autoselect=self._use_autoselect)
         # Add a 'leave' button if the menu-owner has a player.
         if ((self._input_player or self._connected_to_remote_player)
-            and not self._is_kiosk):
+                and not self._is_kiosk):
             h, v, scale = positions[self._p_index]
             self._p_index += 1
             btn = ba.buttonwidget(parent=self._root_widget,
@@ -769,7 +770,7 @@ class MainMenuWindow(ba.Window):
                                   autoselect=self._use_autoselect)
 
             if (player_name != '' and player_name[0] != '<'
-                and player_name[-1] != '>'):
+                    and player_name[-1] != '>'):
                 txt = ba.Lstr(resource=self._r + '.justPlayerText',
                               subs=[('${NAME}', player_name)])
             else:
@@ -865,7 +866,7 @@ class MainMenuWindow(ba.Window):
         # Select cancel by default; this occasionally gets called by accident
         # in a fit of button mashing and this will help reduce damage.
         confirm.ConfirmWindow(ba.Lstr(resource=self._r +
-                                               '.leavePartyConfirmText'),
+                                      '.leavePartyConfirmText'),
                               self._leave_party,
                               cancel_is_selected=True)
 

--- a/assets/src/ba_data/python/bastd/ui/play.py
+++ b/assets/src/ba_data/python/bastd/ui/play.py
@@ -538,7 +538,7 @@ class PlayWindow(ba.Window):
             elif sel == self._back_button:
                 sel_name = 'Back'
             else:
-                raise Exception('unrecognized selected widget')
+                raise ValueError(f'unrecognized selection {sel}')
             ba.app.window_states[self.__class__.__name__] = sel_name
         except Exception:
             ba.print_exception('error saving state for', self.__class__)

--- a/assets/src/ba_data/python/bastd/ui/playlist/__init__.py
+++ b/assets/src/ba_data/python/bastd/ui/playlist/__init__.py
@@ -58,7 +58,7 @@ class PlaylistTypeVars:
                 fallback_resource='freeForAllText')
             self.sessiontype = ba.FreeForAllSession
         else:
-            raise Exception('playlist type vars undefined for session type: ' +
+            raise TypeError('playlist type vars undefined for session type: ' +
                             str(sessiontype))
         self.default_list_name = ba.Lstr(resource='defaultGameListNameText',
                                          subs=[('${PLAYMODE}', play_mode_name)

--- a/assets/src/ba_data/python/bastd/ui/playlist/browser.py
+++ b/assets/src/ba_data/python/bastd/ui/playlist/browser.py
@@ -62,7 +62,7 @@ class PlaylistBrowserWindow(ba.Window):
             ba.app.main_window = 'Free-for-All Game Select'
             ba.set_analytics_screen('FreeForAll Window')
         else:
-            raise Exception(f'invalid sessiontype: {sessiontype}')
+            raise TypeError(f'invalid sessiontype: {sessiontype}')
         self._pvars = playlist.PlaylistTypeVars(sessiontype)
 
         self._sessiontype = sessiontype

--- a/assets/src/ba_data/python/bastd/ui/playlist/editgame.py
+++ b/assets/src/ba_data/python/bastd/ui/playlist/editgame.py
@@ -264,19 +264,19 @@ class PlaylistEditGameWindow(ba.Window):
             if 'choices' in setting:
                 for choice in setting['choices']:
                     if len(choice) != 2:
-                        raise Exception(
+                        raise ValueError(
                             "Expected 2-member tuples for 'choices'; got: " +
                             repr(choice))
                     if not isinstance(choice[0], str):
-                        raise Exception(
+                        raise TypeError(
                             'First value for choice tuple must be a str; got: '
                             + repr(choice))
                     if not isinstance(choice[1], value_type):
-                        raise Exception(
+                        raise TypeError(
                             'Choice type does not match default value; choice:'
                             + repr(choice) + '; setting:' + repr(setting))
                 if value_type not in (int, float):
-                    raise Exception(
+                    raise TypeError(
                         'Choice type setting must have int or float default; '
                         'got: ' + repr(setting))
 
@@ -509,5 +509,5 @@ class PlaylistEditGameWindow(ba.Window):
         elif setting_type == int:
             ba.textwidget(edit=ctrl, text=str(int(val)))
         else:
-            raise Exception('invalid vartype: ' + str(setting_type))
+            raise TypeError('invalid vartype: ' + str(setting_type))
         self._settings[setting_name] = val

--- a/assets/src/ba_data/python/bastd/ui/playoptions.py
+++ b/assets/src/ba_data/python/bastd/ui/playoptions.py
@@ -93,7 +93,7 @@ class PlayOptionsWindow(popup.PopupWindow):
                 elif self._sessiontype is ba.DualTeamSession:
                     plst = get_default_teams_playlist()
                 else:
-                    raise Exception('unrecognized session-type: ' +
+                    raise TypeError('unrecognized session-type: ' +
                                     str(self._sessiontype))
             else:
                 try:

--- a/assets/src/ba_data/python/bastd/ui/popup.py
+++ b/assets/src/ba_data/python/bastd/ui/popup.py
@@ -153,7 +153,7 @@ class PopupMenuWindow(PopupWindow):
         self._choices_disabled = list(choices_disabled)
         self._done_building = False
         if not choices:
-            raise Exception('Must pass at least one choice')
+            raise TypeError('Must pass at least one choice')
         self._width = width
         self._scale = scale
         if len(choices) > 8:
@@ -302,7 +302,7 @@ class PopupMenu:
             current_choice = None
         self._choices = list(choices)
         if not choices:
-            raise Exception('no choices given')
+            raise TypeError('no choices given')
         self._choices_display = list(choices_display)
         self._choices_disabled = list(choices_disabled)
         self._width = width
@@ -313,7 +313,7 @@ class PopupMenu:
         self._position = position
         self._parent = parent
         if not choices:
-            raise Exception('Must pass at least one choice')
+            raise TypeError('Must pass at least one choice')
         self._parent = parent
         self._button_size = button_size
 

--- a/assets/src/ba_data/python/bastd/ui/profile/edit.py
+++ b/assets/src/ba_data/python/bastd/ui/profile/edit.py
@@ -546,7 +546,7 @@ class EditProfileWindow(ba.Window):
         elif picker_type == 'highlight':
             initial_color = self._highlight
         else:
-            raise Exception('invalid picker_type: ' + picker_type)
+            raise ValueError('invalid picker_type: ' + picker_type)
         colorpicker.ColorPicker(
             parent=self._root_widget,
             position=origin,

--- a/assets/src/ba_data/python/bastd/ui/purchase.py
+++ b/assets/src/ba_data/python/bastd/ui/purchase.py
@@ -44,7 +44,7 @@ class PurchaseWindow(ba.Window):
             header_text = ba.Lstr(resource='unlockThisText',
                                   fallback_resource='unlockThisInTheStoreText')
         if len(items) != 1:
-            raise Exception('expected exactly 1 item')
+            raise ValueError('expected exactly 1 item')
         self._items = list(items)
         self._width = 580
         self._height = 520

--- a/assets/src/ba_data/python/bastd/ui/settings/advanced.py
+++ b/assets/src/ba_data/python/bastd/ui/settings/advanced.py
@@ -596,11 +596,11 @@ class AdvancedSettingsWindow(ba.Window):
                 elif sel == self._language_inform_checkbox:
                     sel_name = 'LangInform'
                 else:
-                    raise Exception('unrecognized selection')
+                    raise ValueError(f'unrecognized selection \'{sel}\'')
             elif sel == self._back_button:
                 sel_name = 'Back'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError(f'unrecognized selection \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name
             }

--- a/assets/src/ba_data/python/bastd/ui/settings/allsettings.py
+++ b/assets/src/ba_data/python/bastd/ui/settings/allsettings.py
@@ -252,7 +252,7 @@ class AllSettingsWindow(ba.Window):
             elif sel == self._back_button:
                 sel_name = 'Back'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError(f'unrecognized selection \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name
             }

--- a/assets/src/ba_data/python/bastd/ui/settings/audio.py
+++ b/assets/src/ba_data/python/bastd/ui/settings/audio.py
@@ -266,7 +266,7 @@ class AudioSettingsWindow(ba.Window):
             elif sel == self._vr_head_relative_audio_button:
                 sel_name = 'VRHeadRelative'
             else:
-                raise Exception('unrecognized selected widget')
+                raise ValueError(f'unrecognized selection \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = sel_name
         except Exception:
             ba.print_exception('error saving state for', self.__class__)

--- a/assets/src/ba_data/python/bastd/ui/settings/testing.py
+++ b/assets/src/ba_data/python/bastd/ui/settings/testing.py
@@ -167,7 +167,7 @@ class TestingWindow(ba.Window):
         for entry in self._entries:
             if entry['name'] == name:
                 return entry
-        raise Exception(f'Entry not found: {name}')
+        raise ba.NotFoundError(f'Entry not found: {name}')
 
     def _on_reset_press(self) -> None:
         for entry in self._entries:

--- a/assets/src/ba_data/python/bastd/ui/soundtrack/browser.py
+++ b/assets/src/ba_data/python/bastd/ui/soundtrack/browser.py
@@ -485,7 +485,7 @@ class SoundtrackBrowserWindow(ba.Window):
             elif sel == self._back_button:
                 sel_name = 'Back'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError(f'unrecognized selection \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = sel_name
         except Exception:
             ba.print_exception('error saving state for', self.__class__)

--- a/assets/src/ba_data/python/bastd/ui/store/browser.py
+++ b/assets/src/ba_data/python/bastd/ui/store/browser.py
@@ -1002,7 +1002,7 @@ class StoreBrowserWindow(ba.Window):
                 sel_name = 'Tab:' + list(self._tab_buttons.keys())[list(
                     self._tab_buttons.values()).index(sel)]
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError(f'unrecognized selection \'{sel}\'')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name,
                 'tab': self._current_tab

--- a/assets/src/ba_data/python/bastd/ui/tournamententry.py
+++ b/assets/src/ba_data/python/bastd/ui/tournamententry.py
@@ -69,7 +69,7 @@ class TournamentEntryWindow(popup.PopupWindow):
             self._purchase_price_name = 'price.tournament_entry_1'
         else:
             if self._fee != 0:
-                raise Exception('invalid fee: ' + str(self._fee))
+                raise ValueError('invalid fee: ' + str(self._fee))
             self._purchase_name = 'tournament_entry_0'
             self._purchase_price_name = 'price.tournament_entry_0'
 

--- a/assets/src/ba_data/python/bastd/ui/watch.py
+++ b/assets/src/ba_data/python/bastd/ui/watch.py
@@ -482,7 +482,7 @@ class WatchWindow(ba.Window):
             elif sel == self._tab_container:
                 sel_name = 'TabContainer'
             else:
-                raise Exception('unrecognized selection')
+                raise ValueError(f'unrecognized selection {sel}')
             ba.app.window_states[self.__class__.__name__] = {
                 'sel_name': sel_name,
                 'tab': self._current_tab


### PR DESCRIPTION
Exceptions cleanup (like `raise Exception("emm is it player?")` -> `raise TypeError("emm is it player?")` and `except Exception` -> ...).

FFA player spawn when game begins ~has been fixed~ still works bad (all were spawn only at one-two points). I have no access to internal ba.Player methods, so I can't say more than that something wrong with ba.Player.node (i.e. ba.Player._nodeactor); in short, player._nodeactor return True if player has just joined but hasn't spawned yet (just at the moment of calculating the better position for its spawn).

P.S. **"playerID"** argument for ba.newnode('player') still in camelCase.