### PR TITLE
Use -S flag for /usr/bin/env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Fixed the shebang line in `bombsquad_server` file by using `-S` flag for `/usr/bin/env`.
+
 ### 1.5.22 (20139)
 - Button and key names now display correctly again on Android (and are cleaned up on other platforms too).
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,6 @@
 ### Benefit-Zebra
 - Unofficial BombSquad Bug Finder
 - Code Cleanup
+
+### Ali Borhani
+- Bug fixes

--- a/tools/batools/pcommand.py
+++ b/tools/batools/pcommand.py
@@ -62,7 +62,7 @@ def stage_server_file() -> None:
             lines = infile.read().splitlines()
             if mode == 'release':
                 lines[0] = replace_one(lines[0], '#!/usr/bin/env python3.7',
-                                       '#!/usr/bin/env python3.7 -O')
+                                       '#!/usr/bin/env -S python3.7 -O')
         with open(outfilename, 'w') as outfile:
             outfile.write('\n'.join(lines) + '\n')
         subprocess.run(['chmod', '+x', outfilename], check=True)


### PR DESCRIPTION
## Steps

- [X] Add yourself to CONTRIBUTORS if you are a new contributor.
- [X] Add a CHANGELOG entry describing what your PR does. (I've added it to `Unreleased` section based on https://keepachangelog.com/en/1.0.0/) 
- [X] Ensure `make preflight` completes successfully. (`PREFLIGHT SUCCESSFUL!`)
- [X] Write a good description on what the PR does.

## Description

If you run `./bombsquad_server` (instead of `python3.7 <file>`), it returns the below error because of using `-O` flag for `python3.7` in the shebang line:

```
$ ./bombsquad_server
/usr/bin/env: ‘python3.7 -O’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

This PR adds `-S` flag to `/usr/bin/env` to resolve this issue.

> **-S, --split-string=S**
>               process and split S into separate arguments; used to pass
>               multiple arguments on shebang lines
> https://man7.org/linux/man-pages/man1/env.1.html


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

None
