### PR TITLE
Impact bomb owner fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Fixed a impact bomb bug which caused impact bomb to not blast on its owner.
+
 ### 1.5.23 (20146)
 - Fixed the shebang line in `bombsquad_server` file by using `-S` flag for `/usr/bin/env`.
 - Fixed a bug with hardware keyboards emitting extra characters in the in-game console (~ or F2)

--- a/assets/src/ba_data/python/bastd/actor/bomb.py
+++ b/assets/src/ba_data/python/bastd/actor/bomb.py
@@ -893,11 +893,14 @@ class Bomb(ba.Actor):
         # try:
         node_delegate = node.getdelegate(object)
         if node:
-            if (self.bomb_type == 'impact' and
-                (node is self.owner or
-                 (isinstance(node_delegate, Bomb) and node_delegate.bomb_type
-                  == 'impact' and node_delegate.owner is self.owner))):
-                return
+            # UPDATE (July 2020): Not checking this since this causes impact
+            # bomb to not blast on its owner's head. Holler if anything
+            # seems to be broken.
+            # if (self.bomb_type == 'impact' and
+            #   (node is self.owner or
+            #   (isinstance(node_delegate, Bomb) and node_delegate.bomb_type
+            #     == 'impact' and node_delegate.owner is self.owner))):
+            #   return
             self.handlemessage(ExplodeMessage())
 
     def _handle_dropped(self) -> None:


### PR DESCRIPTION
## Description
Fixed the bug which caused impact bomb to not blast on its owner.  I have commented out those lines. 

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #129 