### PR TITLE
Added Rescan plugins Feature

### DIFF
--- a/assets/src/ba_data/python/ba/_plugin.py
+++ b/assets/src/ba_data/python/ba/_plugin.py
@@ -58,3 +58,6 @@ class Plugin:
 
     def on_app_launch(self) -> None:
         """Called when the app is being launched."""
+
+    def on_disable(self) -> None:
+        """Called when the plugin is disabled."""


### PR DESCRIPTION
## Steps

- [x] Ensure `make preflight` completes successfully.

## Description
It really gets annoying when you have to everytime restart your game when you enable/disable plugin or add a new plugin to folder when the game is on. 

So I have here added a Rescan Plugin button to Plugins Window which will helps us to enable/disable plugin or detect new plugin without restarting the Game. 

According to me, its a very useful feature since in BombSquad 1.4 or older similarly like the plugin case, to compile mods, we needed to restart the game. Thus this will save time of user. 

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |


## Example
```python

    # ba_meta require api 6

    from __future__ import annotations

    from typing import TYPE_CHECKING

    import ba
    from Example import Sample

    if TYPE_CHECKING:
        pass
    
    # Below line is necessary since it helps to restore 
    # the original state when disabling plugin
    copy1 = Example.Sample 

    class NewSample:
    - - snippet - - 

    # ba_meta export plugin
    class MyPlugin(ba.Plugin):
        """My first ballistica plugin!"""

        def on_app_launch(self) -> None:
            Example.Sample = NewSample

       def on_disable(self) -> None:
            Example.Sample = copy1 # Restoring Original State

    ```