### PR TITLE
Meta subsytem now enables new plugin by default in headless builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.5.30 (20263)
+- Meta subsytem now enables new plugin by default in headless builds
+
 ### 1.5.29 (20246)
 - Exposed ba method/class initing in public C++ layer.
 - The 'restart' and 'shutdown' commands in the server script now default to immediate=True

--- a/assets/src/ba_data/python/ba/_meta.py
+++ b/assets/src/ba_data/python/ba/_meta.py
@@ -99,7 +99,16 @@ class MetadataSubsystem:
                                 class_path=class_path,
                                 available=True))
             if class_path not in plugstates:
-                plugstates[class_path] = {'enabled': False}
+                if _ba.app.headless_mode:
+                    # If we running in headless mode, enable plugin by default
+                    # to allow server admins to get their modified build
+                    # working 'out-of-the-box', without manually updating the
+                    # config.
+                    plugstates[class_path] = {'enabled': True}
+                else:
+                    # If we running in normal mode, disable plugin by default
+                    # (user can enable it later).
+                    plugstates[class_path] = {'enabled': False}
                 config_changed = True
                 found_new = True
 


### PR DESCRIPTION
## Description
Meta subsytem now enables new plugin by default in headless builds to allow server admins to get their modified server working 'out-of-the-box', without manually updating the config.

## Type of Changes
| ✓  | :sparkles: New feature |
