### PR TITLE
Remove redundant code

### DIFF
--- a/src/ballistica/scene/node/spaz_node.cc
+++ b/src/ballistica/scene/node/spaz_node.cc
@@ -1109,10 +1109,8 @@ void SpazNode::SetJumpPressed(bool val) {
       }
       last_jump_time_ = scene()->time();
     }
-    jump_pressed_ = true;
   } else {
     // Release.
-    jump_pressed_ = false;
   }
 }
 


### PR DESCRIPTION
## Steps

- [x] Ensure `make preflight` completes successfully.

## Description

It's not required to set `jump_pressed_` again as it is already set beforehand in the 4th line:

https://github.com/efroemling/ballistica/blob/3d52e05bfbb6fd57645cd4dbeea6b9837daa7247/src/ballistica/scene/node/spaz_node.cc#L1089-L1117

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |