### PR TITLE
 Set winner when player leaves elimination mid-game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Declare opponent team as the winner if a player with their final turn leaves an elimination game.
+
 ### 1.6.0 (20357)
 - Revamped netcode significantly. We still don't have client-prediction, but things should (hopefully) feel much lower latency now.
 - Added network debug graphs accessible by hitting F8.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,6 @@
 
 ### Daniil Rakhov
 - Plugin api additions
+
+### Ritiek Malhotra
+- Just <3 BombSquad

--- a/assets/src/ba_data/python/bastd/game/elimination.py
+++ b/assets/src/ba_data/python/bastd/game/elimination.py
@@ -483,6 +483,13 @@ class EliminationGame(ba.TeamGameActivity[Player, Team]):
         # list then.
         ba.timer(0, self._update_icons)
 
+        # If the player to leave was the last in spawn order and had
+        # their final turn currently in-progress, mark the survival time
+        # for their team.
+        if self._get_total_team_lives(player.team) == 0:
+            assert self._start_time is not None
+            player.team.survival_seconds = int(ba.time() - self._start_time)
+
     def _get_total_team_lives(self, team: Team) -> int:
         return sum(player.lives for player in team.players)
 


### PR DESCRIPTION

<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to pylint in this document:
https://github.com/efroemling/ballistica/wiki/Contributing
-->

## Steps

- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a CHANGELOG entry describing what your PR does.
- [x] Ensure `make preflight` completes successfully.
- [x] Write a good description on what the PR does.

## Description
Some players immediately leave the game mid-way in elimination maps
when they have the final turn in the team and they are about to
die/fall off a cliff, which causes the game to draw when the opponent
team should have been declared the winner.

The game will now check if the player to leave the elimination game was
the last player in the team and in case they were so, mark their team
score so the opponent team is declared as the winner.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->