### PR TITLE
Build: parse pip output correctly

### DIFF
--- a/tools/batools/build.py
+++ b/tools/batools/build.py
@@ -561,7 +561,7 @@ def checkenv() -> None:
     piplist = piplist[2:]
     pipvers: Dict[str, List[int]] = {}
     for line in piplist:
-        pname, pverraw = line.split()
+        pname, pverraw = line.split()[:2]
         pver = [int(x) if x.isdigit() else 0 for x in pverraw.split('.')]
         pipvers[pname] = pver
 


### PR DESCRIPTION
## Steps

- [x] Ensure `make preflight` completes successfully.

## Description

If some python package on the system has been installed in editable mode through
```bash
$ python setup.py build
or
$ pip install -e .
```
then
```
$ pip list
```
returns three values for that specific package, in this order: `<package-name> <package-version> <package-install-directory>`. The build script currently fails to parse such packages correctly since it expects only two values (the initial two - `<package-name> <package-version>`):

```bash
$ make cmake-server
Checking environment...                              
Traceback (most recent call last):
  File "tools/pcommand", line 52, in <module>
    pcommand_main(globals())
  File "/home/ritiek/Downloads/ballistica/tools/efrotools/pcommand.py", line 56, in pcommand_main
    funcs[sys.argv[1]]()                             
  File "/home/ritiek/Downloads/ballistica/tools/batools/pcommand.py", line 481, in checkenv
    batools.build.checkenv()
  File "/home/ritiek/Downloads/ballistica/tools/batools/build.py", line 565, in checkenv
    pname, pverraw = line.split()
ValueError: too many values to unpack (expected 2)
make: *** [Makefile:948: .cache/checkenv] Error 1
```

This PR fixes this by explicitly extracting only the first two values.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
