### PR TITLE
Fix SharedObjects

### DIFF
--- a/assets/src/ba_data/python/bastd/gameutils.py
+++ b/assets/src/ba_data/python/bastd/gameutils.py
@@ -26,7 +26,7 @@ class SharedObjects:
 
     def __init__(self) -> None:
         activity = ba.getactivity()
-        if hasattr(activity, self._STORENAME):
+        if self._STORENAME in activity.customdata:
             raise RuntimeError('Use SharedObjects.get() to fetch the'
                                ' shared instance for this activity.')
         self._object_material: Optional[ba.Material] = None


### PR DESCRIPTION
## Description
After changing the storage location of the `SharedObjects` instance (bc22359dcd06b1dea6a1c767ba350783f4fb53f5), you forgot to change the check in `SharedObjects.__init__`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
