### PR TITLE
Own PlayerSpaz

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,6 @@
 
 ### Droopy
 - Fixes in some minigames
+
+### Easy10781
+- Added feature

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -853,7 +853,7 @@ class GameActivity(Activity[PlayerType, TeamType]):
         color = player.color
         highlight = player.highlight
 
-        playerspaztype = getattr(player, 'playerspaztype', None)
+        playerspaztype = getattr(player, 'playerspaztype', PlayerSpaz)
         if not issubclass(playerspaztype, PlayerSpaz):
             playerspaztype = PlayerSpaz
 

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -853,8 +853,8 @@ class GameActivity(Activity[PlayerType, TeamType]):
         color = player.color
         highlight = player.highlight
 
-        playerspaztype = player.playerspaztype
-        if playerspaztype is None:
+        playerspaztype = getattr(player, 'playerspaztype', None)
+        if not issubclass(playerspaztype, PlayerSpaz):
             playerspaztype = PlayerSpaz
 
         light_color = _math.normalized_color(color)

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -852,6 +852,10 @@ class GameActivity(Activity[PlayerType, TeamType]):
         name = player.getname()
         color = player.color
         highlight = player.highlight
+        
+        playerspaztype = player.playerspaztype
+        if playerspaztype is None:
+            playerspaztype = PlayerSpaz
 
         light_color = _math.normalized_color(color)
         display_color = _ba.safecolor(color, target_intensity=0.75)

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -855,10 +855,10 @@ class GameActivity(Activity[PlayerType, TeamType]):
 
         light_color = _math.normalized_color(color)
         display_color = _ba.safecolor(color, target_intensity=0.75)
-        spaz = PlayerSpaz(color=color,
-                          highlight=highlight,
-                          character=player.character,
-                          player=player)
+        spaz = player.playerspaztype(color=color,
+                                     highlight=highlight,
+                                     character=player.character,
+                                     player=player)
 
         player.actor = spaz
         assert spaz.node

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -852,7 +852,7 @@ class GameActivity(Activity[PlayerType, TeamType]):
         name = player.getname()
         color = player.color
         highlight = player.highlight
-        
+
         playerspaztype = player.playerspaztype
         if playerspaztype is None:
             playerspaztype = PlayerSpaz

--- a/assets/src/ba_data/python/ba/_gameactivity.py
+++ b/assets/src/ba_data/python/ba/_gameactivity.py
@@ -859,10 +859,10 @@ class GameActivity(Activity[PlayerType, TeamType]):
 
         light_color = _math.normalized_color(color)
         display_color = _ba.safecolor(color, target_intensity=0.75)
-        spaz = player.playerspaztype(color=color,
-                                     highlight=highlight,
-                                     character=player.character,
-                                     player=player)
+        spaz = playerspaztype(color=color,
+                              highlight=highlight,
+                              character=player.character,
+                              player=player)
 
         player.actor = spaz
         assert spaz.node

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -96,7 +96,7 @@ class Player(Generic[TeamType]):
                 f' in the class decorator.')
 
         self.actor = None
-        self.playerspaztype = None
+        self.playerspaztype = getattr(self, 'playerspaztype'):
         self.character = ''
         self._nodeactor: Optional[ba.NodeActor] = None
         self._sessionplayer = sessionplayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -63,7 +63,7 @@ class Player(Generic[TeamType]):
     color: Sequence[float]
     highlight: Sequence[float]
 
-    playerspaztype: Optional[type['PlayerSpaz']]
+    playerspaztype: Optional[type[PlayerSpaz]]
 
     _team: TeamType
     _sessionplayer: ba.SessionPlayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -96,7 +96,10 @@ class Player(Generic[TeamType]):
                 f' in the class decorator.')
 
         self.actor = None
-        self.playerspaztype = getattr(self, 'playerspaztype'):
+        try:
+            self.playerspaztype = getattr(self, 'playerspaztype')
+        except AttributeError:
+            self.playerspaztype = None
         self.character = ''
         self._nodeactor: Optional[ba.NodeActor] = None
         self._sessionplayer = sessionplayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -15,6 +15,7 @@ from ba._messages import DeathType, DieMessage
 if TYPE_CHECKING:
     from typing import Optional, Sequence, Any, Union, Callable
     import ba
+    from bastd.actor.playerspaz import PlayerSpaz
 
 # pylint: disable=invalid-name
 PlayerType = TypeVar('PlayerType', bound='ba.Player')
@@ -61,6 +62,8 @@ class Player(Generic[TeamType]):
 
     color: Sequence[float]
     highlight: Sequence[float]
+
+    playerspaztype: type['PlayerSpaz']
 
     _team: TeamType
     _sessionplayer: ba.SessionPlayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -96,6 +96,7 @@ class Player(Generic[TeamType]):
                 f' in the class decorator.')
 
         self.actor = None
+        self.playerspaztype = None
         self.character = ''
         self._nodeactor: Optional[ba.NodeActor] = None
         self._sessionplayer = sessionplayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -63,7 +63,7 @@ class Player(Generic[TeamType]):
     color: Sequence[float]
     highlight: Sequence[float]
 
-    playerspaztype: type['PlayerSpaz']
+    playerspaztype: Optional[type['PlayerSpaz']]
 
     _team: TeamType
     _sessionplayer: ba.SessionPlayer

--- a/assets/src/ba_data/python/ba/_player.py
+++ b/assets/src/ba_data/python/ba/_player.py
@@ -96,10 +96,6 @@ class Player(Generic[TeamType]):
                 f' in the class decorator.')
 
         self.actor = None
-        try:
-            self.playerspaztype = getattr(self, 'playerspaztype')
-        except AttributeError:
-            self.playerspaztype = None
         self.character = ''
         self._nodeactor: Optional[ba.NodeActor] = None
         self._sessionplayer = sessionplayer


### PR DESCRIPTION
## Description
Allows you to add your own PlayerSpaz types

Example:
```python
# ba_meta require api 6

import ba
from bastd.actor.playerspaz import PlayerSpaz


class MyPlayerSpaz(PlayerSpaz):
    def on_jump_press(self) -> None:
        ba.screenmessage("Hello from my playerspaz!")


class Player(ba.Player['Team']):
    playerspaztype = MyPlayerSpaz


class Team(ba.Team[Player]):
    pass


# ba_meta export game
class MyGame(ba.TeamGameActivity[Player, Team]):
    name = "Example"
```

## Type of Changes
|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |

