### PR TITLE
Revert _campaign.py

### DIFF
--- a/assets/src/ba_data/python/ba/_campaign.py
+++ b/assets/src/ba_data/python/ba/_campaign.py
@@ -49,12 +49,12 @@ class Campaign:
         """Whether this Campaign's levels must be played in sequence."""
         return self._sequential
 
-    def addlevel(self, level: ba.Level, index: int = -1) -> None:
+    def addlevel(self, level: ba.Level) -> None:
         """Adds a ba.Level to the Campaign."""
         if level.campaign is not None:
             raise RuntimeError('Level already belongs to a campaign.')
         level.set_campaign(self, len(self._levels))
-        self._levels.insert(index, level)
+        self._levels.append(level)
 
     @property
     def levels(self) -> list[ba.Level]:


### PR DESCRIPTION
I found this bug in 1.7.4.

The first game is locked. (Onslaught training)

![BombSquad 08-07-2022 18_37_29](https://user-images.githubusercontent.com/76160371/177998503-5030492f-3ea1-4fe3-82b7-dbe6fa5fa0a4.png)

If i click it , then it tells to complete Uber Runaround. (In easy mode , i finished till uber runaround , so i guess it is showing me that name , it might differ with others , i didn't check it yet)

![BombSquad 08-07-2022 18_37_45](https://user-images.githubusercontent.com/76160371/177999042-20c0be92-0550-45b2-8d50-57f37042aaf3.png)

I hope that this gets fixed.
