### PR TITLE
Update Benchmarks & Stress Tests Text

### DIFF
--- a/assets/src/ba_data/python/ba/_benchmark.py
+++ b/assets/src/ba_data/python/ba/_benchmark.py
@@ -138,7 +138,7 @@ def _reset_stress_test(args: dict[str, Any]) -> None:
 
 def run_gpu_benchmark() -> None:
     """Kick off a benchmark to test gpu speeds."""
-    _ba.screenmessage('FIXME: Not wired up yet.', color=(1, 0, 0))
+    _ba.screenmessage('Not wired up yet.', color=(1, 0, 0))
 
 
 def run_media_reload_benchmark() -> None:

--- a/assets/src/ba_data/python/bastd/ui/settings/advanced.py
+++ b/assets/src/ba_data/python/bastd/ui/settings/advanced.py
@@ -504,7 +504,7 @@ class AdvancedSettingsWindow(ba.Window):
             position=(self._sub_width / 2 - this_button_width / 2, v - 14),
             size=(this_button_width, 60),
             autoselect=True,
-            label=ba.Lstr(resource=self._r + '.benchmarksText'),
+            label='Benchmarks & Stress Tests',
             text_scale=1.0,
             on_activate_call=self._on_benchmark_press)
 


### PR DESCRIPTION
I updated the Text of the stress test button in Settings > Advanced.
From "Benchmarks & Stress-Tests" to "Benchmarks & Stress Tests".

The text is fetched from ba.Lstr function which I don't know how to change so I added the text directly.

Closes #463 