### PR TITLE
Removed Additional Time

### DIFF
--- a/assets/src/ba_data/python/bastd/game/football.py
+++ b/assets/src/ba_data/python/bastd/game/football.py
@@ -732,6 +732,7 @@ class FootballCoopGame(ba.CoopGameActivity[Player, Team]):
                     self._scoring_team = team
                     if team is self._bot_team:
                         self.continue_or_end_game()
+                        ba.app.pause()
                     else:
                         ba.setmusic(ba.MusicType.VICTORY)
 

--- a/assets/src/ba_data/python/bastd/ui/continues.py
+++ b/assets/src/ba_data/python/bastd/ui/continues.py
@@ -162,6 +162,8 @@ class ContinuesWindow(ba.Window):
                 ba.textwidget(edit=self._counter_text, text=str(self._count))
 
     def _on_cancel_press(self) -> None:
+        ba.app.resume()
+
         # disallow for first second
         if self._start_count - self._count < 2:
             ba.playsound(ba.getsound('error'))
@@ -170,6 +172,7 @@ class ContinuesWindow(ba.Window):
 
     def _on_continue_press(self) -> None:
         from bastd.ui import getcurrency
+        ba.app.resume()
 
         # Disallow for first second.
         if self._start_count - self._count < 2:

--- a/assets/src/ba_data/python/bastd/ui/continues.py
+++ b/assets/src/ba_data/python/bastd/ui/continues.py
@@ -202,6 +202,7 @@ class ContinuesWindow(ba.Window):
                 self._continue_call()
 
     def _on_cancel(self) -> None:
+        ba.app.resume()
         if not self._transitioning_out:
             ba.playsound(ba.getsound('swish'))
             self._transitioning_out = True


### PR DESCRIPTION
## Description
After you lose the rookie/pro/uber football game in campaign , the continue or end game window appears. The time that the player takes to choose and click an option (continue or end) also gets calculated into the football game time. 

|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
