### PR TITLE
Fix 'Disable Camera Shake' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.7.9 (build 20877, api 7, 2022-09-21)
 - Cleaned up the efro.message system to isolate response types that are used purely internally (via a new SysResponse type).
+- Fixed bug with 'Disable Camera Shake' option. (GitHub #511)
 
 ### 1.7.8 (build 20871, api 7, 2022-09-21)
 - Fixed tournament scores submits which were broken in 1.7.7 (oops).
@@ -15,7 +16,7 @@
 - Added support for the console tool in the new devices section on ballistica.net.
 - Increased timeouts in net-testing gui and a few other places to be able to better diagnose/handle places with very poor connectivity.
 - Removed `Platform::SetLastPyCall()` which was just for debugging and which has not been useful in a while.
-- Moved some app bootstrapping from the C++ layer to the ba._bootstrap module.
+- Moved some app bootstrapping from the C++ layer to the `ba._bootstrap` module.
 - The game will now properly return to the stress-test window after a stress test finishes (thanks vishal332008!)
 - Continue window will now pause the game to avoid running up times in the background (thanks vishal332008!)
 - Keepaway and KingOfTheHill now have epic options (thanks FAL-Guys!)
@@ -23,9 +24,9 @@
 - Starting to rename the 'game' thread to the 'logic' thread. This is the thread where most high level app logic happen, not only game logic.
 - `_ba.in_game_thread()` is now `_ba.in_logic_thread()`.
 - Misc C++ layer tidying/refactoring.
-- Split out the `_ba` binary module into `_ba` and `_bainternal`. This will eventually allow running without the closed-source parts (_bainternal) present at all.
+- Split out the `_ba` binary module into `_ba` and `_bainternal`. This will eventually allow running without the closed-source parts (`_bainternal`) present at all.
 - There is now a `_bainternal.py` dummy-module alongside the existing `_ba.py` one. Be sure to exclude it from any script collections used by the game (the same as `_ba.py`).
-- Added checks to make sure _ba or _bainternal arent used outside of ba. Any 'internal' functionality needed outside of ba should be exposed through ba.internal. _ba and _bainternal are internal implementation details.
+- Added checks to make sure `_ba` or `_bainternal` arent used outside of ba. Any 'internal' functionality needed outside of ba should be exposed through ba.internal. `_ba` and `_bainternal` are internal implementation details.
 - Removed C++ Module class and simplified Thread class. The Module class was an old relic of long ago before C++ had lambdas and its existence was pretty pointless and confusing these days.
 - Renamed C++ App to AppFlavor and AppGlobals to App.
 - Renamed C++ Media to Assets.
@@ -34,14 +35,14 @@
 - Renamed C++ Game classes to Logic.
 - The app now bootstraps Python in the main thread instead of the logic thread. This will keep things more consistent later when we are able to run under an already-existing Python interpreter.
 - As a side-effect of initing Python in the main thread, it seems that Python now catches segfaults in our debug builds and prints Python stack traces. (see https://docs.python.org/3/library/faulthandler.html). We'll have to experiment and see if this is a net positive or something we want to disable or make optional.
-- Python and _ba are now completely initialized in public source code. Now we just need to enable the app to survive without _bainternal and it'll be possible to build a 100% open source app.
+- Python and `_ba` are now completely initialized in public source code. Now we just need to enable the app to survive without `_bainternal` and it'll be possible to build a 100% open source app.
 - `Logging::Log()` in the C++ layer now takes a LogLevel arg (kDebug, kWarning, kError, etc.) and simply calls the equivalent Python logging.XXX call. This unifies our C++ and Python logging to go through the same place.
 - `ba.log()` is no more. Instead just use standard Python logging functions (logging.info(), logging.error(), etc.).
-- `_ba.getlog()` is now `_ba.get_v1_cloud_log()`. Note that this functionality will go away eventually so you should use ba.app.log_handler and/or standard Python logging functions to get at app logs.
+- `_ba.getlog()` is now `_ba.get_v1_cloud_log()`. Note that this functionality will go away eventually so you should use `ba.app.log_handler` and/or standard Python logging functions to get at app logs.
 - Along the same lines, `_ba.get_log_file_path()` is now `_ba.get_v1_cloud_log_file_path()`.
 - Added `_ba.display_log()` function which ships a log message to the in-game terminal and platform-specific places like the Android log. The engine wires up standard Python logging output to go through this.
 - Added `_ba.v1_cloud_log()` which ships a message to the old v1-cloud-log (the log which is gathered and sent to the v1 master server to help me identify problems people are seeing). This is presently wired up to a subset of Python logging output to approximate how it used to work.
-- Note: Previously in the C++ layer some code would mix Python print calls (such as PyErr_PrintEx()) with ballistica::Log() calls. Previously these all wound up going to the same place (Python's sys.stderr) so it worked, but now they no longer do and so this sort of mixing should be avoided. So if you see a weird combination of colored log output lines with non-colored lines that seem to go together, please holler as it means something needs to be fixed.
+- Note: Previously in the C++ layer some code would mix Python print calls (such as `PyErr_PrintEx()`) with ballistica::Log() calls. Previously these all wound up going to the same place (Python's sys.stderr) so it worked, but now they no longer do and so this sort of mixing should be avoided. So if you see a weird combination of colored log output lines with non-colored lines that seem to go together, please holler as it means something needs to be fixed.
 - Builds for Apple devices now explicitly set a thread stack size of 1MB. The default there is 512k and I was seeing some stack overflows for heavy physics sims or very recursive Python stuff.
 - If you want to grab recent logs, you can now use `ba.app.log_handler.get_cached()`. This will give you everything that has gone through Python logging, Python stdout/stderr, and the C++ Log() call (up to the max cache size that is).
 - LogHandler output now ALWAYS goes to stderr. Previously it only would if an interactive terminal was detected. This should make the binary easier to debug if run from scripts/etc. We can add a `--quiet` option if needed or whatnot.
@@ -53,7 +54,7 @@
 
 ### 1.7.6 (build 20687, api 7, 2022-08-11)
 - Cleaned up the MetaSubsystem code.
-- It is now possible to tell the meta system about arbitrary classes (ba_meta export foo.bar.Class) instead of just the preset types 'plugin', 'game', etc.
+- It is now possible to tell the meta system about arbitrary classes (ba\_meta export foo.bar.Class) instead of just the preset types 'plugin', 'game', etc.
 - Newly discovered plugins are now activated immediately instead of requiring a restart.
 
 ### 1.7.5 (build 20672, api 7, 2022-07-25)

--- a/src/ballistica/graphics/camera.cc
+++ b/src/ballistica/graphics/camera.cc
@@ -727,7 +727,7 @@ void Camera::Update(millisecs_t elapsed) {
     }
 
     if (g_graphics->camera_shake_disabled()) {
-      shake_vel_ = {0, 0, 0};
+      shake_pos_ = {0, 0, 0};
     }
   }
 


### PR DESCRIPTION
## Steps
- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Add a CHANGELOG entry if your change is non-trivial.
- [x] Ensure `make preflight` completes successfully.

## Description
Line 725 looks like something that tries to slowly return `shake_pos_` to {0, 0, 0}, but it can't be successful if we reset `shake_vel_` (line 730).
https://github.com/efroemling/ballistica/blob/3197caaff42338529d74645648808832f82762c3/src/ballistica/graphics/camera.cc#L723-L731

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |

## Related Issue
Closes #511 
