### PR TITLE
filtering unavailable maps from playlist

### DIFF
--- a/assets/src/ba_data/python/ba/_playlist.py
+++ b/assets/src/ba_data/python/ba/_playlist.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import _ba
 import copy
 import logging
 from typing import Any, TYPE_CHECKING
@@ -36,6 +37,7 @@ def filter_playlist(playlist: PlaylistType,
     from ba._gameactivity import GameActivity
     goodlist: list[dict] = []
     unowned_maps: Sequence[str]
+    available_maps: list[str] = list(_ba.app.maps.keys())
     if remove_unowned or mark_unowned:
         unowned_maps = get_unowned_maps()
         unowned_game_types = get_unowned_game_types()
@@ -123,6 +125,11 @@ def filter_playlist(playlist: PlaylistType,
                     'bastd.game.targetpractice.TargetPracticeGame')
 
             gameclass = getclass(entry['type'], GameActivity)
+
+            if entry['settings']['map'] not in available_maps:
+                raise ImportError(
+                    f"Map not found: '{entry['settings']['map']}'"
+                )
 
             if remove_unowned and gameclass in unowned_game_types:
                 continue

--- a/assets/src/ba_data/python/ba/_playlist.py
+++ b/assets/src/ba_data/python/ba/_playlist.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-import _ba
 import copy
 import logging
 from typing import Any, TYPE_CHECKING
+
+import _ba
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -128,8 +129,7 @@ def filter_playlist(playlist: PlaylistType,
 
             if entry['settings']['map'] not in available_maps:
                 raise ImportError(
-                    f"Map not found: '{entry['settings']['map']}'"
-                )
+                    f"Map not found: '{entry['settings']['map']}'")
 
             if remove_unowned and gameclass in unowned_game_types:
                 continue


### PR DESCRIPTION
<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, make sure to complete the following steps.

You can also read more about contributing to Ballistica in this document:
https://ballistica.net/wiki/Contributing
-->


## Description
Filter out unavailable maps from a playlist to avoid blank screen/crashes.

Right now if playlist contains a map which is not installed on server then server stucks on scorescreen.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |


<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
