### PR TITLE
ffa scoring

### DIFF
--- a/assets/src/ba_data/python/ba/_freeforallsession.py
+++ b/assets/src/ba_data/python/ba/_freeforallsession.py
@@ -74,9 +74,15 @@ class FreeForAllSession(MultiTeamSession):
             # Award different point amounts based on number of players.
             point_awards = self.get_ffa_point_awards()
 
-            for i, winner in enumerate(winners):
+            award_index = -1
+            for winner in winners:
+                award_index += len(winner.teams)
                 for team in winner.teams:
-                    points = point_awards[i] if i in point_awards else 0
+                    points = (
+                        point_awards[award_index]
+                        if award_index in point_awards
+                        else 0
+                    )
                     team.customdata['previous_score'] = team.customdata['score']
                     team.customdata['score'] += points
 

--- a/assets/src/ba_data/python/bastd/activity/freeforallvictory.py
+++ b/assets/src/ba_data/python/bastd/activity/freeforallvictory.py
@@ -53,7 +53,6 @@ class FreeForAllVictoryScoreScreenActivity(MultiTeamScoreScreenActivity):
             reverse=True,
             key=lambda p: (
                 p.team.sessionteam.customdata['score'],
-                p.team.sessionteam.customdata['score'],
                 p.getname(full=True),
             ),
         )


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a CHANGELOG entry if your change is non-trivial.
- [x] Ensure `make preflight` completes successfully.

## Description
Currently if multiple players receive same maximum number of points, they both get +8. This also annoying when there is only one guy who e.g. was the only one who held flag for all 30 seconds (others 0) and this guy will receive +8 meanwhile other receive +4. This PR makes it that player with same number of points receive that much series points as would receive last of them (not first, as now).

|name|final before|final now|game|
|--|--|--|--|
|spaz|+8| +8|100|
|zoe|+4| +2|50|
|kronk|+4| +2|50|
|pascal|+2| +1|0|

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
