### PR TITLE
Fixed the CTF Flag Bug

### DIFF
--- a/assets/src/ba_data/python/bastd/game/capturetheflag.py
+++ b/assets/src/ba_data/python/bastd/game/capturetheflag.py
@@ -482,10 +482,7 @@ class CaptureTheFlagGame(ba.TeamGameActivity[Player, Team]):
         try:
             spaz = ba.getcollision().sourcenode.getdelegate(PlayerSpaz, True)
         except ba.NotFoundError:
-            return
-
-        if not spaz.is_alive():
-            return
+            return     
 
         player = spaz.getplayer(Player, True)
 
@@ -522,6 +519,9 @@ class CaptureTheFlagGame(ba.TeamGameActivity[Player, Team]):
                     team.touch_return_timer_ticking = None
             if team.flag_return_touches < 0:
                 ba.print_error('CTF flag_return_touches < 0')
+        
+        if not spaz.is_alive():
+            return
 
     def _flash_base(self, team: Team, length: float = 2.0) -> None:
         light = ba.newnode(


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [x] Ensure `make preflight` completes successfully.

## Description
There was an issue on how the flag return was handled. When the player who at the time was returning the flag died, the counter wouldn't stop and the flag would still return to the base.  Funny part? This bug would persist through the entire match. The only way to temporarily fix it was to throw the flag out of bounds.

I provided a simple fix, so now when the player who returns the flag dies, the flag won't return by itself.

Here's a quick presentation on how the flag behaves now:
https://youtu.be/ItF1f7mibDs



## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
