### PR TITLE
Update code.py

### DIFF
--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)  # type: ignore[attr-defined]
+    return black.format_str(code, mode=black_mode)  # type: ignore
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)  # mypy: ignore
+    return black.format_str(code, mode=black_mode)  # type: ignore
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -24,7 +24,7 @@ from efrotools.filecache import FileCache
 
 # pylint: enable=useless-suppression, wrong-import-order
 
-black_mode = black.Mode(line_length=80)
+black_mode = black.Mode(line_length=80)  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from typing import Any
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)  # type: ignore
+    return black.format_str(code, mode=black_mode)
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)  # mypy: allow-attr-defined
+    return black.format_str(code, mode=black_mode)  # mypy: ignore
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)
+    return black.format_str(code, mode=black_mode)  # type: ignore[attr-defined]
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -312,7 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return black.format_str(code, mode=black_mode)  # type: ignore
+    return black.format_str(code, mode=black_mode)  # mypy: allow-attr-defined
 
 
 def _should_include_script(fnamefull: str) -> bool:

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -614,6 +614,9 @@ def _apply_pylint_run_to_cache(
     # Add a few that this package itself triggers.
     ignored_untracked_deps |= {'pylint.lint', 'astroid.modutils', 'astroid'}
 
+    # Add black
+    ignored_untracked_deps |= {'black'}
+
     # EW; as of Python 3.9, suddenly I'm seeing system modules showing up
     # here where I wasn't before. I wonder what changed. Anyway, explicitly
     # suppressing them here but should come up with a more robust system

--- a/tools/efrotools/code.py
+++ b/tools/efrotools/code.py
@@ -14,6 +14,8 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import black
+
 from efro.error import CleanError
 
 # WTF Pylint. This is our package. It goes last.
@@ -22,6 +24,7 @@ from efrotools.filecache import FileCache
 
 # pylint: enable=useless-suppression, wrong-import-order
 
+black_mode = black.Mode(line_length=80)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -309,11 +312,7 @@ def format_project_python_files(projroot: Path, full: bool) -> None:
 def format_python_str(code: str) -> str:
     """Run our Python formatting on the provided inline code."""
 
-    return subprocess.run(
-        black_base_args() + ['--code', code],
-        capture_output=True,
-        check=True,
-    ).stdout.decode()
+    return black.format_str(code, mode=black_mode)
 
 
 def _should_include_script(fnamefull: str) -> bool:


### PR DESCRIPTION
Switching from calling black with subprocess to direct use

## Description
Transition from using black via subprocess to calling black format function directly to avoid path limit exceeded error on windows and (i think) speed up format process

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|   | :hammer: Refactoring   |
|    | :scroll: Docs          |

