### PR TITLE
Fix possible DoS vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 1.7.23 (build 21164, api 8, 2023-07-11)
+- Network security improvements.
 
 ### 1.7.22 (build 21162, api 8, 2023-07-11)
 

--- a/src/ballistica/scene_v1/connection/connection.cc
+++ b/src/ballistica/scene_v1/connection/connection.cc
@@ -439,6 +439,10 @@ void Connection::HandleMessagePacket(const std::vector<uint8_t>& buffer) {
         Log(LogLevel::kError, "got invalid BA_MESSAGE_MULTIPART");
       }
       if (buffer[0] == BA_MESSAGE_MULTIPART_END) {
+        if (multipart_buffer_[0] == BA_MESSAGE_MULTIPART) {
+          BA_LOG_ONCE(LogLevel::kError, "nested multipart message detected; kicking");
+          Error("");
+        }
         HandleMessagePacket(multipart_buffer_);
         multipart_buffer_.clear();
       }


### PR DESCRIPTION
## Description
A lot of nested multipart messages may trigger an allocation of a really huge amount of memory, which OS couldn't handle.

This PR disallows nested multipart messages.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
