### PR TITLE
Fixed PlayerSpaz using bs.apptime() instead of bs.time() for last_attacked_time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,9 +41,8 @@
 - Modder
 
 ### Era0S
-- Fixed a single bug
+- Bug Fixer
 - Modder
-- Made a SUPER important change
 
 ### VinniTR
 - Fixes

--- a/src/assets/ba_data/python/bascenev1lib/actor/playerspaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/playerspaz.py
@@ -209,7 +209,7 @@ class PlayerSpaz(Spaz):
             picked_up_by = msg.node.source_player
             if picked_up_by:
                 self.last_player_attacked_by = picked_up_by
-                self.last_attacked_time = bs.apptime()
+                self.last_attacked_time = bs.time()
                 self.last_attacked_type = ('picked_up', 'default')
         elif isinstance(msg, bs.StandMessage):
             super().handlemessage(msg)  # Augment standard behavior.
@@ -247,7 +247,7 @@ class PlayerSpaz(Spaz):
                         #  something like last_actor_attacked_by to fix that.
                         if (
                             self.last_player_attacked_by
-                            and bs.apptime() - self.last_attacked_time < 4.0
+                            and bs.time() - self.last_attacked_time < 4.0
                         ):
                             killerplayer = self.last_player_attacked_by
                         else:
@@ -278,7 +278,7 @@ class PlayerSpaz(Spaz):
             source_player = msg.get_source_player(type(self._player))
             if source_player:
                 self.last_player_attacked_by = source_player
-                self.last_attacked_time = bs.apptime()
+                self.last_attacked_time = bs.time()
                 self.last_attacked_type = (msg.hit_type, msg.hit_subtype)
             super().handlemessage(msg)  # Augment standard behavior.
             activity = self._activity()


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Update CONTRIBUTORS.md
- [x] Ensure `make preflight` completes successfully.

## Description

PlayerSpaz should use the scene's time for handling things, but it accidentally got changed to use the app time instead during the transition to api 8

## Type of Changes
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |