### PR TITLE
Fixed issue with hockey puck dying

### DIFF
--- a/src/assets/ba_data/python/bascenev1lib/game/hockey.py
+++ b/src/assets/ba_data/python/bascenev1lib/game/hockey.py
@@ -60,11 +60,12 @@ class Puck(bs.Actor):
 
     def handlemessage(self, msg: Any) -> Any:
         if isinstance(msg, bs.DieMessage):
-            assert self.node
-            self.node.delete()
-            activity = self._activity()
-            if activity and not msg.immediate:
-                activity.handlemessage(PuckDiedMessage(self))
+            if self.node:
+                self.node.delete()
+                self.node = None
+                activity = self._activity()
+                if activity and not msg.immediate:
+                    activity.handlemessage(PuckDiedMessage(self))
 
         # If we go out of bounds, move back to where we started.
         elif isinstance(msg, bs.OutOfBoundsMessage):

--- a/src/assets/ba_data/python/bascenev1lib/game/hockey.py
+++ b/src/assets/ba_data/python/bascenev1lib/game/hockey.py
@@ -62,7 +62,6 @@ class Puck(bs.Actor):
         if isinstance(msg, bs.DieMessage):
             if self.node:
                 self.node.delete()
-                self.node = None
                 activity = self._activity()
                 if activity and not msg.immediate:
                     activity.handlemessage(PuckDiedMessage(self))


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Ensure `make preflight` completes successfully.

## Description

There was always a bug annoying me when working with mods regarding how the hockey puck handles a non-immediate bs.DieMessage, causing the puck to respawn indefinitely, this PR ensures that this won't happen.

## Type of Changes
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |