### PR TITLE
Added the reject_recently_left_players plugin into the base game

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,10 @@
 ### Era0S
 - Bug Fixer
 - Modder
+- Added a feature
 
 ### VinniTR
 - Fixes
+
+### Rikko
+- Created the original "reject_recently_left_players" plugin

--- a/src/assets/ba_data/python/bascenev1/_session.py
+++ b/src/assets/ba_data/python/bascenev1/_session.py
@@ -3,6 +3,7 @@
 """Defines base session class."""
 from __future__ import annotations
 
+import math
 import weakref
 import logging
 from typing import TYPE_CHECKING
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
     from typing import Sequence, Any
 
     import bascenev1
+
+TIMEOUT = 10
 
 
 class Session:
@@ -203,6 +206,10 @@ class Session:
         # Instantiate our session globals node which will apply its settings.
         self._sessionglobalsnode = _bascenev1.newnode('sessionglobals')
 
+        self._players_on_wait: dict = {}
+        self._player_requested_identifiers: dict = {}
+        self._waitlist_timers: dict = {}
+
     @property
     def context(self) -> bascenev1.ContextRef:
         """A context-ref pointing at this activity."""
@@ -253,6 +260,26 @@ class Session:
                 )
                 return False
 
+        identifier = player.get_v1_account_id()
+        if identifier:
+            leave_time = self._players_on_wait.get(identifier)
+            if leave_time:
+                diff = str(math.ceil(TIMEOUT - babase.apptime() + leave_time))
+                _bascenev1.broadcastmessage(
+                    babase.Lstr(
+                        translate=(
+                            'serverResponses',
+                            'You can join in ${COUNT} seconds.',
+                        ),
+                        subs=[('${COUNT}', diff)],
+                    ),
+                    color=(1, 1, 0),
+                    clients=[player.inputdevice.client_id],
+                    transient=True,
+                )
+                return False
+            self._player_requested_identifiers[player.id] = identifier
+
         _bascenev1.getsound('dripity').play()
         return True
 
@@ -269,6 +296,15 @@ class Session:
         _bascenev1.getsound('playerLeft').play()
 
         activity = self._activity_weak()
+
+        identifier = self._player_requested_identifiers.get(sessionplayer.id)
+        if identifier:
+            self._players_on_wait[identifier] = babase.apptime()
+            with babase.ContextRef.empty():
+                self._waitlist_timers[identifier] = babase.AppTimer(
+                    TIMEOUT,
+                    babase.Call(self._remove_player_from_waitlist, identifier),
+                )
 
         if not sessionplayer.in_game:
             # Ok, the player is still in the lobby; simply remove them.
@@ -770,3 +806,9 @@ class Session:
         if pass_to_activity:
             activity.add_player(sessionplayer)
         return sessionplayer
+
+    def _remove_player_from_waitlist(self, identifier) -> None:
+        try:
+            self._players_on_wait.pop(identifier)
+        except KeyError:
+            pass

--- a/src/assets/ba_data/python/bascenev1/_session.py
+++ b/src/assets/ba_data/python/bascenev1/_session.py
@@ -807,7 +807,7 @@ class Session:
             activity.add_player(sessionplayer)
         return sessionplayer
 
-    def _remove_player_from_waitlist(self, identifier) -> None:
+    def _remove_player_from_waitlist(self, identifier: str) -> None:
         try:
             self._players_on_wait.pop(identifier)
         except KeyError:


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Add Rikko to CONTRIBUTORS.
- [ ] Add a CHANGELOG entry if your change is non-trivial.
- [x] Ensure `make preflight` completes successfully.

## Description
Imagine killing someone, them having to wait 7 seconds to respawn, and they just disconnect and reconnect and they're able to hop in the game immediately without having to wait even a second.

Originally a plugin by @rikkolovescats, this PR disallows any pb-id from joining the session for 10 seconds once the player leaves the session, this system works like the system in the c-layer that disallows people from joining for 10 seconds after they leave, but this system supports disconnections and reconnections, allowing a fair game.

It's also worth noting that this system does not stop people from joining if authenticate_clients is set to false in the config and the player sends a join request to the server before the server fetches the pb-id, this is intentional as the server has requested the client to not be authenticated.

## Type of Changes
|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |