### PR TITLE
Automatic prefab builds for each push and PR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,178 @@
+name: CD
+
+on:
+  # Run on pushes and pull-requests
+  push:
+  pull_request:
+
+jobs:
+  make_linux_x86_64_gui_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-gui-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux_x86_64_gui_(debug)
+        path: build/prefab/full/linux_x86_64_gui
+  make_linux_x86_64_server_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-server-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux_x86_64_server_(debug)
+        path: build/prefab/full/linux_x86_64_server
+  make_linux_arm64_gui_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-linux-arm64-gui-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux_arm64_gui_(debug)
+        path: build/prefab/full/linux_arm64_gui
+  make_linux_arm64_server_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-linux-arm64-server-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux_arm64_server_(debug)
+        path: build/prefab/full/linux_arm64_server
+  make_mac_x86_64_gui_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-mac-x86-64-gui-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: mac_x86_64_gui_(debug)
+        path: build/prefab/full/mac_x86_64_gui
+  make_mac_x86_64_server_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-mac-x86-64-server-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: mac_x86_64_server_(debug)
+        path: build/prefab/full/mac_x86_64_server
+  make_mac_arm64_gui_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-mac-arm64-gui-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: mac_arm64_gui_(debug)
+        path: build/prefab/full/mac_arm64_gui
+  make_mac_arm64_server_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-mac-arm64-server-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: mac_arm64_server_(debug)
+        path: build/prefab/full/mac_arm64_server
+  make_windows_x86_gui_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-windows-x86-gui-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows_x86_gui_(debug)
+        path: build/prefab/full/windows_x86_gui
+  make_windows_x86_server_debug_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install pip requirements
+      run: tools/pcommand install_pip_reqs
+    - name: Make the build
+      run: make prefab-windows-x86-server-debug-build
+    - name: Upload the build
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows_x86_server_(debug)
+        path: build/prefab/full/windows_x86_server

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ height="50" alt="logo">
 
 ***-ica***: collection of things relating to a specific theme.
 
-[![](https://github.com/efroemling/ballistica/actions/workflows/ci.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/ci.yml)
+[![](https://github.com/efroemling/ballistica/actions/workflows/ci.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/ci.yml) [![](https://github.com/efroemling/ballistica/actions/workflows/cd.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/cd.yml)
 
 The Ballistica project is the foundation for
 [BombSquad](https://www.froemling.net/apps/bombsquad) and potentially other
@@ -52,7 +52,7 @@ want to keep that spirit alive as the Ballistica project moves forward. Whether
 this means making it easier to share mods, organize tournaments, join up with
 friends, teach each other some Python, or whatever else. Life is short; let's
 play some games. Or make them. Maybe both.
-  
+
 ### Frequently Asked Questions
 
 * **Q: What's with this name? Is it BombSquad or Ballistica?**
@@ -86,4 +86,4 @@ Playstation / My Toaster??**
   for more details or the [Ballistica
   Downloads](https://ballistica.net/downloads) page for early test builds on
   some platforms.
-  
+

--- a/config/spinoffconfig.py
+++ b/config/spinoffconfig.py
@@ -195,6 +195,7 @@ ctx.filter_file_names = {
     '.projectile',
     '.editorconfig',
     'ci.yml',
+    'cd.yml',
     'LICENSE',
     'cloudtool',
     'bacloud',


### PR DESCRIPTION
## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Ensure `make preflight` completes successfully.

## Description
This PR adds a new workflow file named CD, this workflow gets triggered on pushes and PRs and makes and uploads the following builds as artifacts:
- prefab-linux-x86-64-gui-debug
- prefab-linux-x86-64-server-debug
- prefab-linux-arm64-gui-debug
- prefab-linux-arm64-server-debug
- prefab-mac-x86-64-gui-debug
- prefab-mac-x86-64-server-debug
- prefab-mac-arm64-gui-debug
- prefab-mac-arm64-server-debug
- prefab-windows-x86-gui-debug
- prefab-windows-x86-server-debug

This makes it easier for people to test new commits and review PRs.

[Here it is in action](https://github.com/efroemling/ballistica/actions/runs/7097493079)