### PR TITLE
Respawn step indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Players now get points for killing bots with their own bombs by catching it
   and throwing it back at them. This is actually old logic but was disabled due
   to a logic flaw, but should be fixed now. (Thanks VinniTR!)
+- Respawn icons now have dotted steps showing decimal progress to assist
+  players on calculating when they are gonna respawn. (Thanks Temp!)
   
 ### 1.7.32 (build 21741, api 8, 2023-12-20)
 - Fixed a screen message that no one will ever see (Thanks vishal332008?...)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,6 @@
 
 ### Rikko
 - Created the original "reject_recently_left_players" plugin
+
+### Temp (3alTemp)
+- Modder & Bug Fixer

--- a/src/assets/ba_data/python/bascenev1lib/actor/respawnicon.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/respawnicon.py
@@ -23,6 +23,7 @@ class RespawnIcon:
     def __init__(self, player: bs.Player, respawn_time: float):
         """Instantiate with a Player and respawn_time (in seconds)."""
         self._visible = True
+        self._dots_epic_only = False
 
         on_right, offs_extra, respawn_icons = self._get_context(player)
 
@@ -110,26 +111,33 @@ class RespawnIcon:
             )
         )
         dpos = [ipos[0] + (7 if on_right else -7), ipos[1] - 16]
-        self._dec_text: bs.NodeActor | None = bs.NodeActor(
-            bs.newnode(
-                'text',
-                attrs={
-                    'position': dpos,
-                    'h_attach': 'right' if on_right else 'left',
-                    'h_align': 'right' if on_right else 'left',
-                    'scale': 0.65,
-                    'shadow': 0.5,
-                    'flatness': 0.5,
-                    'v_attach': 'top',
-                    'color': bs.safecolor(icon['tint_color']),
-                    'text': '...',
-                },
+        self._dec_text: bs.NodeActor | None = None
+        if (
+            self._dots_epic_only
+            and bs.getactivity().globalsnode.slow_motion
+            or not self._dots_epic_only
+        ):
+            self._dec_text = bs.NodeActor(
+                bs.newnode(
+                    'text',
+                    attrs={
+                        'position': dpos,
+                        'h_attach': 'right' if on_right else 'left',
+                        'h_align': 'right' if on_right else 'left',
+                        'scale': 0.65,
+                        'shadow': 0.5,
+                        'flatness': 0.5,
+                        'v_attach': 'top',
+                        'color': bs.safecolor(icon['tint_color']),
+                        'text': '',
+                    },
+                )
             )
-        )
 
         assert self._text.node
         bs.animate(self._text.node, 'scale', {0: 0, 0.1: 0.9})
-        bs.animate(self._dec_text.node, 'scale', {0: 0, 0.1: 0.65})
+        if self._dec_text:
+            bs.animate(self._dec_text.node, 'scale', {0: 0, 0.1: 0.65})
 
         self._respawn_time = bs.time() + respawn_time
         self._update()
@@ -146,7 +154,7 @@ class RespawnIcon:
         """Return info on where we should be shown and stored."""
         activity = bs.getactivity()
 
-        if isinstance(bs.getsession(), bs.DualTeamSession):
+        if isinstance(activity.session, bs.DualTeamSession):
             on_right = player.team.id % 2 == 1
 
             # Store a list of icons in the team.
@@ -181,10 +189,11 @@ class RespawnIcon:
             assert self._text is not None
             if self._text.node:
                 self._text.node.text = str(remaining)
-                self._dec_text.node.text = '...'
-                bs.timer(0.25, dec_step)
-                bs.timer(0.5, dec_step)
-                bs.timer(0.75, dec_step)
+                if self._dec_text:
+                    self._dec_text.node.text = '...'
+                    bs.timer(0.25, dec_step)
+                    bs.timer(0.5, dec_step)
+                    bs.timer(0.75, dec_step)
         else:
             self._visible = False
             self._image = (

--- a/src/assets/ba_data/python/bascenev1lib/actor/respawnicon.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/respawnicon.py
@@ -92,7 +92,7 @@ class RespawnIcon:
         assert self._name.node
         bs.animate(self._name.node, 'scale', {0: 0, 0.1: 0.5})
 
-        tpos = (-60 - h_offs if on_right else 60 + h_offs, -192 + offs)
+        tpos = (-60 - h_offs if on_right else 60 + h_offs, -193 + offs)
         self._text: bs.NodeActor | None = bs.NodeActor(
             bs.newnode(
                 'text',
@@ -109,9 +109,27 @@ class RespawnIcon:
                 },
             )
         )
+        dpos = [ipos[0] + (7 if on_right else -7), ipos[1] - 16]
+        self._dec_text: bs.NodeActor | None = bs.NodeActor(
+            bs.newnode(
+                'text',
+                attrs={
+                    'position': dpos,
+                    'h_attach': 'right' if on_right else 'left',
+                    'h_align': 'right' if on_right else 'left',
+                    'scale': 0.65,
+                    'shadow': 0.5,
+                    'flatness': 0.5,
+                    'v_attach': 'top',
+                    'color': bs.safecolor(icon['tint_color']),
+                    'text': '...',
+                },
+            )
+        )
 
         assert self._text.node
         bs.animate(self._text.node, 'scale', {0: 0, 0.1: 0.9})
+        bs.animate(self._dec_text.node, 'scale', {0: 0, 0.1: 0.65})
 
         self._respawn_time = bs.time() + respawn_time
         self._update()
@@ -155,10 +173,20 @@ class RespawnIcon:
 
     def _update(self) -> None:
         remaining = int(round(self._respawn_time - bs.time()))
+
+        def dec_step():
+            self._dec_text.node.text = self._dec_text.node.text[:-1]
+
         if remaining > 0:
             assert self._text is not None
             if self._text.node:
                 self._text.node.text = str(remaining)
+                self._dec_text.node.text = '...'
+                bs.timer(0.25, dec_step)
+                bs.timer(0.5, dec_step)
+                bs.timer(0.75, dec_step)
         else:
             self._visible = False
-            self._image = self._text = self._timer = self._name = None
+            self._image = (
+                self._text
+            ) = self._dec_text = self._timer = self._name = None


### PR DESCRIPTION
## Description
Inherited from [this discord post I made a while ago](https://discord.com/channels/1001896771347304639/1186952153760288818), it adds a decimal step indicator to the respawn icon time to help players see when they are gonna respawn better. I chose this design over decimals because as Eric pointed out, decimals would send a lot of setattr messages to clients, this being a solid alternative that is readable and uses considerably less updates.

### Normal mode
https://github.com/efroemling/ballistica/assets/79161340/536c3cee-f87b-4d69-bdc8-9ada56794baa

### Epic mode (ft. putrid compression)
https://github.com/efroemling/ballistica/assets/79161340/454942a0-2828-49c8-86ef-9eeae1fb98d8

By default, it works on both normal and epic mode, though I left a ``self._dots_epic_only`` variable that makes this feature epic mode exclusive, where it's more useful to have at.

## Type of Mimi
|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |