### PR TITLE
 Power-ups affecting melee combat

### DIFF
--- a/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 import bascenev1 as bs
 
 from bascenev1lib.actor.bomb import Bomb, Blast
-from bascenev1lib.actor.powerupbox import PowerupBoxFactory
+from bascenev1lib.actor.powerupbox import PowerupBoxFactory, PowerupBox
 from bascenev1lib.actor.spazfactory import SpazFactory
 from bascenev1lib.gameutils import SharedObjects
 
@@ -1226,6 +1226,8 @@ class Spaz(bs.Actor):
             if not self.node:
                 return None
             node = bs.getcollision().opposingnode
+            if node.getdelegate(PowerupBox):
+                return
 
             # Only allow one hit per node per punch.
             if node and (node not in self._punched_nodes):

--- a/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
@@ -1227,7 +1227,7 @@ class Spaz(bs.Actor):
                 return None
             node = bs.getcollision().opposingnode
             if node.getdelegate(PowerupBox):
-                return
+                return None
 
             # Only allow one hit per node per punch.
             if node and (node not in self._punched_nodes):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, make sure to complete the following steps.

You can also read more about contributing to Ballistica in this document:
https://ballistica.net/wiki/Contributing
-->

## Description
Power-ups are affecting melee combat, why? Because these can be hit, you take knockback and this puts you at a disadvantage, It's like you punch a wall. 
In the case of hitting your opponent who was nearby, the damage will be less than that received by the great immovable box. Thanks to this pr, it will be less complicated to fight near the power-ups placed in the middle.
Also it doesn't make any sense that you can hit powerups and receive knockback if they disappear with touch, I think this makes it easier for you to grab them if you hit them

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
