### PR TITLE
Support IPv6 address on manualtab

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,6 @@
 
 ### Rikko
 - Created the original "reject_recently_left_players" plugin
+
+### brostos
+- Added support for joining using ipv6 address

--- a/src/assets/ba_data/python/bauiv1lib/gather/manualtab.py
+++ b/src/assets/ba_data/python/bauiv1lib/gather/manualtab.py
@@ -48,7 +48,7 @@ class _HostLookupThread(Thread):
         try:
             import socket
 
-            result = socket.gethostbyname(self._name)
+            result = [item[-1][0] for item in socket.getaddrinfo(self.name, self._port)][0]
         except Exception:
             result = None
         bui.pushcall(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, make sure to complete the following steps.

You can also read more about contributing to Ballistica in this document:
https://ballistica.net/wiki/Contributing
-->

## Steps
## Description
This is a simple fix that allows player to use ipv6 addresses on the manual tab to connect to servers and maybe their friends party. The method used earlier `socket.gethostbyname` only supports ipv4 so instead i switched it to `socket.getaddrinfo` that support both protocols.
Some video samples here of before and after.


https://github.com/efroemling/ballistica/assets/67740566/ea2ffe79-82b9-4fe1-8d3a-29723a899b37


https://github.com/efroemling/ballistica/assets/67740566/d3b5c066-adf9-45be-ac4f-30ba7e898c1f


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :bug: Bug fix          |

