### PR TITLE
Automatic Update Checks on Main Menu Startup

### DIFF
--- a/src/assets/ba_data/python/bascenev1lib/mainmenu.py
+++ b/src/assets/ba_data/python/bascenev1lib/mainmenu.py
@@ -875,7 +875,7 @@ class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
             )
 
     def _on_update_check_response(self, data: dict[str, Any] | None) -> None:
-        global SEND_UPDATE_MESSAGE
+        global SEND_UPDATE_MESSAGE  # pylint: disable=global-statement
         if (
             SEND_UPDATE_MESSAGE
             and data

--- a/src/assets/ba_data/python/bascenev1lib/mainmenu.py
+++ b/src/assets/ba_data/python/bascenev1lib/mainmenu.py
@@ -16,7 +16,7 @@ import bauiv1 as bui
 if TYPE_CHECKING:
     from typing import Any
 
-_send_update_message = True
+SEND_UPDATE_MESSAGE = True
 
 
 class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
@@ -875,9 +875,9 @@ class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
             )
 
     def _on_update_check_response(self, data: dict[str, Any] | None) -> None:
-        global _send_update_message  # pylint: disable=global-statement
+        global SEND_UPDATE_MESSAGE  # pylint: disable=global-statement
         if (
-            _send_update_message
+            SEND_UPDATE_MESSAGE
             and data
             and data.get('build_number', 0) > bs.app.env.engine_build_number
         ):
@@ -889,7 +889,7 @@ class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
                 ' Settings->Advanced)',
                 (1.0, 1.0, 0.0),
             )
-            _send_update_message = False
+            SEND_UPDATE_MESSAGE = False
             with self.context:
                 bs.getsound('ding').play(host_only=True)
 

--- a/src/assets/ba_data/python/bascenev1lib/mainmenu.py
+++ b/src/assets/ba_data/python/bascenev1lib/mainmenu.py
@@ -16,7 +16,7 @@ import bauiv1 as bui
 if TYPE_CHECKING:
     from typing import Any
 
-SEND_UPDATE_MESSAGE = True
+_send_update_message = True
 
 
 class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
@@ -875,9 +875,9 @@ class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
             )
 
     def _on_update_check_response(self, data: dict[str, Any] | None) -> None:
-        global SEND_UPDATE_MESSAGE  # pylint: disable=global-statement
+        global _send_update_message  # pylint: disable=global-statement
         if (
-            SEND_UPDATE_MESSAGE
+            _send_update_message
             and data
             and data.get('build_number', 0) > bs.app.env.engine_build_number
         ):
@@ -889,7 +889,7 @@ class MainMenuActivity(bs.Activity[bs.Player, bs.Team]):
                 ' Settings->Advanced)',
                 (1.0, 1.0, 0.0),
             )
-            SEND_UPDATE_MESSAGE = False
+            _send_update_message = False
             with self.context:
                 bs.getsound('ding').play(host_only=True)
 

--- a/src/assets/ba_data/python/bauiv1lib/settings/advanced.py
+++ b/src/assets/ba_data/python/bauiv1lib/settings/advanced.py
@@ -1,5 +1,6 @@
 # Released under the MIT License. See LICENSE for details.
 #
+# pylint: disable=too-many-lines
 """UI functionality for advanced settings."""
 
 from __future__ import annotations
@@ -900,6 +901,7 @@ class AdvancedSettingsWindow(bui.Window):
 
     def _restore_state(self) -> None:
         # pylint: disable=too-many-branches
+        # pylint: disable=too-many-statements
         try:
             assert bui.app.classic is not None
             sel_name = bui.app.ui_v1.window_states.get(type(self), {}).get(

--- a/src/assets/ba_data/python/bauiv1lib/settings/advanced.py
+++ b/src/assets/ba_data/python/bauiv1lib/settings/advanced.py
@@ -90,7 +90,7 @@ class AdvancedSettingsWindow(bui.Window):
         self._scroll_width = self._width - (100 + 2 * x_inset)
         self._scroll_height = self._height - 115.0
         self._sub_width = self._scroll_width * 0.95
-        self._sub_height = 870.0
+        self._sub_height = 912.0
 
         if self._show_always_use_internal_keyboard:
             self._sub_height += 62
@@ -461,6 +461,16 @@ class AdvancedSettingsWindow(bui.Window):
             size=(self._sub_width - 100, 30),
             configkey='Show Ping',
             displayname=bui.Lstr(resource=f'{self._r}.showInGamePingText'),
+            scale=1.0,
+            maxwidth=430,
+        )
+
+        v -= 42
+        self._auto_update_check_box = ConfigCheckBox(
+            parent=self._subcontainer,
+            position=(50, v),
+            size=(self._sub_width - 100, 30),
+            configkey='Automatically Check for Updates',
             scale=1.0,
             maxwidth=430,
         )
@@ -844,6 +854,8 @@ class AdvancedSettingsWindow(bui.Window):
                     sel_name = 'ShowDeprecatedLoginTypes'
                 elif sel == self._show_game_ping_check_box.widget:
                     sel_name = 'ShowPing'
+                elif sel == self._auto_update_check_box.widget:
+                    sel_name = 'AutoUpdateCheck'
                 elif sel == self._disable_camera_shake_check_box.widget:
                     sel_name = 'DisableCameraShake'
                 elif (
@@ -915,6 +927,8 @@ class AdvancedSettingsWindow(bui.Window):
                     sel = self._show_deprecated_login_types_check_box.widget
                 elif sel_name == 'ShowPing':
                     sel = self._show_game_ping_check_box.widget
+                elif sel_name == 'AutoUpdateCheck':
+                    sel = self._auto_update_check_box.widget
                 elif sel_name == 'DisableCameraShake':
                     sel = self._disable_camera_shake_check_box.widget
                 elif (


### PR DESCRIPTION
## My Tasks

- [x] Add update checker.
- [x] Add setting to toggle the update check
- [x] Ensure `make preflight` completes successfully.
- [x] Write PR Description.

## Eric Stuff

- [ ] Add a legacy page (http://legacy.ballistica.net/bsLatestBuildNumber) that returns the latest stable/release build number (or the latest beta build number if `debug` is set to true) as `{'build_number': BuildNumberInt}`. We can also just add a file to this repository and fetch from that if you don't want to add more stuff to the v1 master server.
- [ ] Add `'Automatically Check for Updates'` to the game's built-in config keys with a default value of `False`.
- [ ] Add and use 3 new `Lstr`s.
- [ ] Add a CHANGELOG entry.

## Description

This PR adds an update checker (disabled by default) to the game. It does not perform any sort of update, however it notifies the player once an update is available (the player will only get notified once per game launch). This is somewhat useful for installs that are not from an app store (Mainly PC installs).

## Type of Changes

|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |
