### PR TITLE
Add official Black formatter to workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check"
+          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
           
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
+          black_args: ". --target-version py312 --line-length 80 --skip-string-normalization"
           
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,14 +6,13 @@ on:
   pull_request:
 
 jobs:
-  linter_name:
-    name: runner / black formatter
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rickstaa/action-black@v1
+      - uses: psf/black@stable
         with:
-          black_args: ". --target-version py312 --line-length 80 --skip-string-normalization"
+          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
           
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
 
 jobs:
-  lint:
+   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
+          options: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
           
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,22 @@ on:
   pull_request:
 
 jobs:
+  linter_name:
+    name: runner / black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
+        with:
+          black_args: "."
+      - name: Annotate diff changes using reviewdog
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: blackfmt
+          
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,20 +7,13 @@ on:
 
 jobs:
   linter_name:
-    name: runner / black
+    name: runner / black formatter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check files using the black formatter
-        uses: rickstaa/action-black@v1
-        id: action_black
+      - uses: rickstaa/action-black@v1
         with:
-          black_args: "."
-      - name: Annotate diff changes using reviewdog
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: reviewdog/action-suggester@v1
-        with:
-          tool_name: blackfmt
+          black_args: ". --check"
           
   make_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,13 @@ jobs:
   # We run most of our testing only on linux but it should apply to mac too;
   # we can always add an explicit mac job later if it seems worthwhile.
   linter_name:
-    name: runner / black
+    name: runner / black formatter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check files using the black formatter
-        uses: rickstaa/action-black@v1
-        id: action_black
+      - uses: rickstaa/action-black@v1
         with:
-          black_args: "."
-      - name: Annotate diff changes using reviewdog
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: reviewdog/action-suggester@v1
-        with:
-          tool_name: blackfmt
+          black_args: ". --check"
           
   check_linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check"
+          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
           
   check_linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: ". --target-version py312 --line-length 80 --skip-string-normalization"
+          options: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
           
   check_linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ jobs:
 
   # We run most of our testing only on linux but it should apply to mac too;
   # we can always add an explicit mac job later if it seems worthwhile.
-  linter_name:
-    name: runner / black formatter
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rickstaa/action-black@v1
+      - uses: psf/black@stable
         with:
-          black_args: ". --target-version py312 --line-length 80 --skip-string-normalization"
+          options: ". --target-version py312 --line-length 80 --skip-string-normalization"
           
   check_linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
+          black_args: ". --target-version py312 --line-length 80 --skip-string-normalization"
           
   check_linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,22 @@ jobs:
 
   # We run most of our testing only on linux but it should apply to mac too;
   # we can always add an explicit mac job later if it seems worthwhile.
+  linter_name:
+    name: runner / black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
+        with:
+          black_args: "."
+      - name: Annotate diff changes using reviewdog
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: blackfmt
+          
   check_linux:
     runs-on: ubuntu-22.04
     steps:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@
 
 ### brostos
 - Added support for joining using ipv6 address
+- Added black formatter to the workflow
 
 ### Loup Garou
 - Added sphinx documentation generation


### PR DESCRIPTION
## Steps
Adds a black formarter to the repo's workflow to ensure ci and cd yml  are passing.
I made the changes based on the [wiki](https://github.com/efroemling/ballistica/wiki#:~:text=efrotools.code.black_base_args()).

```python
def black_base_args(projroot: Path) -> list[str]:
    """Build base args for running black Python formatting."""
    from efrotools.pyver import PYVER, get_project_python_executable

    pyver = 'py' + PYVER.replace('.', '')
    if len(pyver) != 5:
        raise RuntimeError('Py version filtering err.')

    return [
        get_project_python_executable(projroot),
        '-m',
        'black',
        '--target-version',
        pyver,
        '--line-length',
        '80',
        '--skip-string-normalization',
    ]
equivalent to 
```

``` yaml
black_args: ". --check --target-version py312 --line-length 80 --skip-string-normalization"
```
Here is the link to black documentation https://black.readthedocs.io/en/stable/integrations/github_actions.html
## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :hammer: Refactoring   |