### PR TITLE
Small fix

### DIFF
--- a/src/assets/ba_data/python/babase/_meta.py
+++ b/src/assets/ba_data/python/babase/_meta.py
@@ -327,7 +327,7 @@ class DirectoryScan:
         meta_lines = {
             lnum: l[1:].split()
             for lnum, l in enumerate(flines)
-            if '# ba_meta ' in l
+            if l.startswith('# ba_meta ')
         }
         is_top_level = len(subpath.parts) <= 1
         required_api = self._get_api_requirement(


### PR DESCRIPTION
It should select the line as meta line only when it starts with `# ba_meta ...` and not if `# ba_meta ` is included in it.
Breaks some plugins such as api updaters and stuff which uses (this is an example -> ) `line.replace('# ba_meta require api 7', '# ba_meta require api 8')` .
As you can see the example, it has `# ba_meta ` in it but it's not a meta line, so yeah. This update should probably fix it.