### PR TITLE
caching python venv for workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -28,6 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -46,6 +68,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -64,6 +97,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -31,6 +42,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -49,6 +71,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -67,6 +100,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
+          ${{ runner.os }}-venv-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -9,8 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Cache Python venv
+        id: cache-venv
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-python-dependencies
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-venv-${{ env.cache-name }}-
+            ${{ runner.os }}-venv-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
+        - name: Cache Python venv
+          id: cache-venv
+          uses: actions/cache@v4
+          env:
+            cache-name: cache-python-dependencies
+          with:
+            path: .venv
+            key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-venv-${{ env.cache-name }}-
+              ${{ runner.os }}-venv-
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
@@ -40,6 +51,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
+        - name: Cache Python venv
+          id: cache-venv
+          uses: actions/cache@v4
+          env:
+            cache-name: cache-python-dependencies
+          with:
+            path: .venv
+            key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-venv-${{ env.cache-name }}-
+              ${{ runner.os }}-venv-
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
@@ -70,6 +92,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
+        - name: Cache Python venv
+          id: cache-venv
+          uses: actions/cache@v4
+          env:
+            cache-name: cache-python-dependencies
+          with:
+            path: .venv
+            key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-venv-${{ env.cache-name }}-
+              ${{ runner.os }}-venv-
         - name: Set up Python
           uses: actions/setup-python@v5
           with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,18 @@ jobs:
   release_linux_x86_64_gui_debug_build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Cache Python venv
+        id: cache-venv
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-python-dependencies
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-venv-${{ env.cache-name }}-
+            ${{ runner.os }}-venv-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -37,8 +47,18 @@ jobs:
   release_linux_x86_64_server_debug_build:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+        - uses: actions/checkout@v4
+        - name: Cache Python venv
+          id: cache-venv
+          uses: actions/cache@v4
+          env:
+            cache-name: cache-python-dependencies
+          with:
+            path: .venv
+            key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-venv-${{ env.cache-name }}-
+              ${{ runner.os }}-venv-
         - name: Setup Python
           uses: actions/setup-python@v5
           with:
@@ -60,6 +80,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -81,6 +111,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -201,6 +241,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -234,6 +284,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -267,6 +327,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -300,6 +370,16 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -355,6 +435,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -388,6 +478,16 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -448,6 +548,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Cache Python venv
+      id: cache-venv
+      uses: actions/cache@v4
+      env:
+        cache-name: cache-python-dependencies
+      with:
+        path: .venv
+        key: ${{ runner.os }}-venv-${{ env.cache-name }}-${{ hashFiles('config/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-${{ env.cache-name }}-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
This pr adds python venv caching to the linux builds
Only linux build because other platform builds dont run as often
here is the comparison in time reduction before and after this change
Notice the time for **Setup project environment**
<img width="1263" height="617" alt="Screenshot From 2025-08-23 23-34-33" src="https://github.com/user-attachments/assets/4e42da01-7d51-4cec-9c29-910821fefd9c" />
<img width="1263" height="617" alt="Screenshot From 2025-08-23 23-34-22" src="https://github.com/user-attachments/assets/e5f5b2b5-993b-4b6c-ba5b-f1fbe6f5341b" />

