### PR TITLE
Fix spawn order handling for solo mode

### DIFF
--- a/src/assets/ba_data/python/bascenev1lib/game/elimination.py
+++ b/src/assets/ba_data/python/bascenev1lib/game/elimination.py
@@ -578,8 +578,9 @@ class EliminationGame(bs.TeamGameActivity[Player, Team]):
 
             # In solo, put ourself at the back of the spawn order.
             if self._solo_mode:
-                player.team.spawn_order.remove(player)
-                player.team.spawn_order.append(player)
+                if player in player.team.spawn_order:
+                    player.team.spawn_order.remove(player)
+                    player.team.spawn_order.append(player)
 
     def _update(self) -> None:
         if self._solo_mode:


### PR DESCRIPTION
[BUG] In solo elim mode, when a player leaves and their actor alive. As the spawn order is already removed from on_player_leave (because its called first from the Activity) And it'll handle DieMessage of the dying player if its alive and try to remove it while its already removed. Causing ValueError and spaz not dying in the GameActivity.

https://github.com/efroemling/ballistica/blob/main/src/assets/ba_data/python/bascenev1lib/game/elimination.py#L524-L526