### PR TITLE
Update README.md to use relative links for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ height="50" alt="logo">
 
 ***-ica***: collection of things relating to a specific theme.
 
-[![](https://github.com/efroemling/ballistica/actions/workflows/ci.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/ci.yml) [![](https://github.com/efroemling/ballistica/actions/workflows/cd.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/cd.yml) [![](https://github.com/efroemling/ballistica/actions/workflows/nightly.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/nightly.yml) [![Deploy Documentation](https://github.com/efroemling/ballistica/actions/workflows/deploy_docs.yml/badge.svg)](https://github.com/efroemling/ballistica/actions/workflows/deploy_docs.yml) [![status-badge](https://ci.codeberg.org/api/badges/14102/status.svg)](https://ci.codeberg.org/repos/14102)
+[![](../../actions/workflows/ci.yml/badge.svg)](../../actions/workflows/ci.yml) [![](../../actions/workflows/cd.yml/badge.svg)](../../actions/workflows/cd.yml) [![](../../actions/workflows/nightly.yml/badge.svg)](../../actions/workflows/nightly.yml) [![Deploy Documentation](../../actions/workflows/deploy_docs.yml/badge.svg)](../../actions/workflows/deploy_docs.yml) [![status-badge](https://ci.codeberg.org/api/badges/14102/status.svg)](https://ci.codeberg.org/repos/14102)
 
 The Ballistica project is the foundation for
 [BombSquad](https://www.froemling.net/apps/bombsquad) and potentially other


### PR DESCRIPTION
use relative links for status badges in readme so that it displays the fork's status instead of upstream