### PR TITLE
Refactor damage handling and sound effects

### DIFF
--- a/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
@@ -1015,7 +1015,6 @@ class Spaz(bs.Actor):
                 )
 
                 damage = int(damage_scale * self.node.damage)
-            self.node.handlemessage('hurt_sound')
 
             # Play punch impact sound based on damage if it was a punch.
             if msg.hit_type == 'punch':
@@ -1149,13 +1148,16 @@ class Spaz(bs.Actor):
                     1.0 - float(self.hitpoints) / self.hitpoints_max
                 )
 
-                # If we're frozen, shatter.. otherwise die if we hit zero
+                # If we're frozen, shatter.. Otherwise, die if we hit zero...
+                # Otherwise, we'll just make a sound of pain. 
                 if self.frozen and (damage > 200 or self.hitpoints <= 0):
                     self.shatter()
                 elif self.hitpoints <= 0:
                     self.node.handlemessage(
                         bs.DieMessage(how=bs.DeathType.IMPACT)
                     )
+                else:
+                    self.node.handlemessage('hurt_sound')
 
             # If we're dead, take a look at the smoothed damage value
             # (which gives us a smoothed average of recent damage) and shatter

--- a/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
@@ -1149,7 +1149,7 @@ class Spaz(bs.Actor):
                 )
 
                 # If we're frozen, shatter.. Otherwise, die if we hit zero...
-                # Otherwise, we'll just make a sound of pain. 
+                # Otherwise, we'll just make a sound of pain.
                 if self.frozen and (damage > 200 or self.hitpoints <= 0):
                     self.shatter()
                 elif self.hitpoints <= 0:


### PR DESCRIPTION

<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, make sure to complete the following steps.

You can also read more about contributing to Ballistica in this document:
https://ballistica.net/wiki/Contributing
-->

## Description
Removed the hurt_sound message call when handling damage and added it to the else condition to prevent it from making a hurt 
sound when you die, to avoid a bit of sound overload and a more unique death if you die flying and screaming. 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |


<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
