### PR TITLE
feat: add controller rumble/haptic feedback for local and networked players

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,3 +85,6 @@
 ### TheMikirog
 - Punch grab exploit fix
 - Volume slider value to perceived volume fix
+
+### sedbytes
+- Implement Controller Haptics / Rumble

--- a/src/assets/ba_data/python/bascenev1/_player.py
+++ b/src/assets/ba_data/python/bascenev1/_player.py
@@ -266,6 +266,40 @@ class Player[TeamT]:
         assert not self._expired
         self._sessionplayer.resetinput()
 
+    def rumble(
+        self,
+        low_freq: float = 1.0,
+        high_freq: float = 1.0,
+        duration_ms: int = 150,
+    ) -> None:
+        """Trigger haptic feedback (controller rumble) for this player.
+
+        low_freq and high_freq are normalized motor intensities in the
+        0.0 to 1.0 range; duration_ms is how long to sustain it. Does
+        nothing if the player no longer exists or their input device
+        doesn't support haptics (keyboards, touchscreens, remote clients
+        without haptics, etc). Also honors the user's global
+        'Controller Rumble' on/off and 'Controller Rumble Intensity'
+        settings, scaling or fully suppressing the request accordingly.
+        """
+        assert self._postinited
+        if self._expired or not self.exists():
+            return
+        cfg = babase.app.config
+        if not cfg.get('Controller Rumble', True):
+            return
+        multiplier = cfg.get('Controller Rumble Intensity', 1.0)
+        if multiplier <= 0.0:
+            return
+        try:
+            self._sessionplayer.inputdevice.rumble(
+                low_freq=min(1.0, low_freq * multiplier),
+                high_freq=min(1.0, high_freq * multiplier),
+                duration_ms=duration_ms,
+            )
+        except babase.NotFoundError:
+            pass
+
     def __bool__(self) -> bool:
         return self.exists()
 

--- a/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
+++ b/src/assets/ba_data/python/bascenev1lib/actor/spaz.py
@@ -554,6 +554,31 @@ class Spaz(bs.Actor):
     def on_punched(self, damage: int) -> None:
         """Called when this spaz gets punched."""
 
+    def _rumble_from_hit(self, damage: int) -> None:
+        """Rumble the controller of the player that owns this spaz.
+
+        Scaled by how much damage they just took. Only ever touches the
+        controller of the player actually getting hit; never a broadcast
+        to other players' controllers.
+        """
+        player = self.source_player
+        if player is None or not player.exists():
+            return
+        if damage <= 0:
+            return
+        # Controller motors typically need a minimum duty-cycle to
+        # physically spin at all, so a linear damage->intensity mapping
+        # left ordinary hits too weak to feel. Floor it, and cap at the
+        # same 500-damage threshold this file already treats as a
+        # 'strong' hit (see punch sound above).
+        scale = min(1.0, damage / 500.0)
+        intensity = 0.3 + 0.7 * scale
+        player.rumble(
+            low_freq=intensity,
+            high_freq=0.6 * intensity,
+            duration_ms=int(80 + 120 * scale),
+        )
+
     def get_death_points(self, how: bs.DeathType) -> tuple[int, int]:
         """Get the points awarded for killing this spaz."""
         del how  # Unused.
@@ -1014,6 +1039,7 @@ class Spaz(bs.Actor):
 
                 damage = int(damage_scale * self.node.damage)
             self.node.handlemessage('hurt_sound')
+            self._rumble_from_hit(damage)
 
             # Play punch impact sound based on damage if it was a punch.
             if msg.hit_type == 'punch':

--- a/src/assets/ba_data/python/bauiv1lib/config.py
+++ b/src/assets/ba_data/python/bauiv1lib/config.py
@@ -33,11 +33,18 @@ class ConfigCheckBox:
         autoselect: bool = True,
         value_change_call: Callable[[Any], Any] | None = None,
         check_box_id: str | None = None,
+        fallback_value: bool = False,
     ):
         if displayname is None:
             displayname = configkey
         self._value_change_call = value_change_call
         self._configkey = configkey
+        try:
+            value = bui.app.config.resolve(configkey)
+        except KeyError:
+            # Not a builtin config key; fall back to a plain dict lookup
+            # (see AppConfig.resolve()'s docs on ad-hoc config values).
+            value = bui.app.config.get(configkey, fallback_value)
         self.widget = bui.checkboxwidget(
             parent=parent,
             id=check_box_id,
@@ -46,7 +53,7 @@ class ConfigCheckBox:
             size=size,
             text=displayname,
             textcolor=(0.8, 0.8, 0.8),
-            value=bui.app.config.resolve(configkey),
+            value=value,
             on_value_change_call=self._value_changed,
             scale=scale,
             maxwidth=maxwidth,

--- a/src/assets/ba_data/python/bauiv1lib/settings/controls.py
+++ b/src/assets/ba_data/python/bauiv1lib/settings/controls.py
@@ -92,6 +92,16 @@ class ControlsSettingsWindow(bui.MainWindow):
         if show_xinput_toggle:
             buttons_height += spacing
 
+        # Rumble is only wired up for local SDL-backed gamepads so far;
+        # tie its visibility to the same check used for the gamepads
+        # button above.
+        show_rumble_settings = show_gamepads
+        if show_rumble_settings:
+            buttons_height += spacing * 2
+            # The two new rows push past the window's fixed base height,
+            # so grow it to match (only when they're actually present).
+            height += spacing * 2
+
         assert bui.app.classic is not None
 
         # Do some fancy math to fill all available screen area up to the
@@ -347,6 +357,49 @@ class ControlsSettingsWindow(bui.MainWindow):
                 edit=xinput_checkbox,
                 left_widget=xinput_checkbox,
                 right_widget=xinput_checkbox,
+            )
+            v -= spacing
+
+        if show_rumble_settings:
+            # pylint: disable=cyclic-import
+            from bauiv1lib.config import ConfigCheckBox, ConfigNumberEdit
+
+            self._rumble_checkbox = rumble_checkbox = ConfigCheckBox(
+                parent=self._root_widget,
+                configkey='Controller Rumble',
+                position=(
+                    width * (0.35 if uiscale is bui.UIScale.SMALL else 0.25),
+                    v + 3,
+                ),
+                size=(120, 30),
+                displayname=bui.Lstr(
+                    resource=f'{self._r}.rumbleText',
+                    fallback_value='Controller Vibration',
+                ),
+                maxwidth=200,
+                fallback_value=True,
+            )
+            bui.widget(
+                edit=rumble_checkbox.widget,
+                left_widget=rumble_checkbox.widget,
+                right_widget=rumble_checkbox.widget,
+            )
+            v -= spacing
+
+            self._rumble_intensity_numedit = ConfigNumberEdit(
+                parent=self._root_widget,
+                idprefix=f'{self.main_window_id_prefix}|rumbleintensity',
+                position=(width * 0.5 - 160, v),
+                configkey='Controller Rumble Intensity',
+                displayname=bui.Lstr(
+                    resource=f'{self._r}.rumbleIntensityText',
+                    fallback_value='Vibration Strength',
+                ),
+                minval=0.0,
+                maxval=1.0,
+                increment=0.1,
+                fallback_value=1.0,
+                as_percent=True,
             )
             v -= spacing
 

--- a/src/ballistica/base/app_adapter/app_adapter_sdl.cc
+++ b/src/ballistica/base/app_adapter/app_adapter_sdl.cc
@@ -988,6 +988,24 @@ auto AppAdapterSDL::GetSDLJoystickInput_(int sdl_joystick_id) const
   return nullptr;  // Epic fail.
 }
 
+void AppAdapterSDL::RumbleJoystick(int sdl_joystick_id, float low_freq,
+                                   float high_freq, int duration_ms) {
+  assert(g_core->InMainThread());
+  if (sdl_joystick_id < 0
+      || static_cast<size_t>(sdl_joystick_id) >= sdl_joystick_handles_.size()) {
+    return;
+  }
+  SDL_Joystick* handle = sdl_joystick_handles_[sdl_joystick_id];
+  if (handle == nullptr) {
+    return;
+  }
+  auto to_u16 = [](float v) -> uint16_t {
+    return static_cast<uint16_t>(std::clamp(v, 0.0f, 1.0f) * 65535.0f);
+  };
+  SDL_RumbleJoystick(handle, to_u16(low_freq), to_u16(high_freq),
+                     static_cast<uint32_t>(std::max(0, duration_ms)));
+}
+
 void AppAdapterSDL::ReloadRenderer_(const GraphicsSettings_* settings) {
   assert(g_base->app_adapter->InGraphicsContext());
 

--- a/src/ballistica/base/app_adapter/app_adapter_sdl.h
+++ b/src/ballistica/base/app_adapter/app_adapter_sdl.h
@@ -53,6 +53,12 @@ class AppAdapterSDL : public AppAdapter {
 
   auto GetKeyName(int keycode) -> std::string override;
 
+  /// Trigger hardware rumble on the SDL joystick with the given
+  /// instance-id. No-ops if that id doesn't correspond to a currently
+  /// open SDL_Joystick handle.
+  void RumbleJoystick(int sdl_joystick_id, float low_freq, float high_freq,
+                      int duration_ms);
+
  protected:
   void DoPushMainThreadRunnable(Runnable* runnable) override;
   void RunMainThreadEventLoopToCompletion() override;

--- a/src/ballistica/base/graphics/support/graphics_client_context.cc
+++ b/src/ballistica/base/graphics/support/graphics_client_context.cc
@@ -8,8 +8,8 @@
 namespace ballistica::base {
 
 GraphicsClientContext::GraphicsClientContext()
-    : auto_graphics_quality{
-          g_base->graphics_server->renderer()->GetAutoGraphicsQuality()},
+    : auto_graphics_quality{g_base->graphics_server->renderer()
+                                ->GetAutoGraphicsQuality()},
       auto_texture_quality{
           g_base->graphics_server->renderer()->GetAutoTextureQuality()},
       texture_compression_types{

--- a/src/ballistica/base/input/device/input_device.h
+++ b/src/ballistica/base/input/device/input_device.h
@@ -73,6 +73,13 @@ class InputDevice : public Object {
   /// Read and apply new control values from config.
   virtual void ApplyAppConfig();
 
+  /// Trigger controller rumble/haptic feedback if the device supports it.
+  /// Default implementation does nothing. low_freq/high_freq are normalized
+  /// motor intensities in [0.0, 1.0] (mirrors dual-motor gamepad rumble: a
+  /// low-frequency 'strong' motor and a high-frequency 'weak' motor);
+  /// duration_ms is how long to sustain it.
+  virtual void Rumble(float low_freq, float high_freq, int duration_ms) {}
+
 #if BA_SDL_BUILD || BA_MINSDL_BUILD
   virtual void HandleSDLEvent(const BAEvent* e);
 #endif

--- a/src/ballistica/base/input/device/joystick_input.cc
+++ b/src/ballistica/base/input/device/joystick_input.cc
@@ -7,6 +7,9 @@
 #include <string>
 
 #include "ballistica/base/app_adapter/app_adapter.h"
+#if BA_SDL_BUILD
+#include "ballistica/base/app_adapter/app_adapter_sdl.h"
+#endif
 #include "ballistica/base/assets/assets.h"
 #include "ballistica/base/input/input.h"
 #include "ballistica/base/python/base_python.h"
@@ -429,6 +432,22 @@ void JoystickInput::ResetHeldStates() {
   HandleSDLEvent(&e);
 
   resetting_ = false;
+}
+
+void JoystickInput::Rumble(float low_freq, float high_freq, int duration_ms) {
+#if BA_SDL_BUILD
+  if (is_sdl_joystick_) {
+    // We're running in the logic thread here, but AppAdapterSDL (and the
+    // SDL_Joystick handles it owns) is only safe to touch from the main
+    // thread, so hop over there instead of calling straight through.
+    int sdl_joystick_id{sdl_joystick_id_};
+    g_base->app_adapter->PushMainThreadCall(
+        [sdl_joystick_id, low_freq, high_freq, duration_ms] {
+          AppAdapterSDL::Get()->RumbleJoystick(sdl_joystick_id, low_freq,
+                                               high_freq, duration_ms);
+        });
+  }
+#endif
 }
 
 void JoystickInput::HandleSDLEvent(const BAEvent* e) {

--- a/src/ballistica/base/input/device/joystick_input.h
+++ b/src/ballistica/base/input/device/joystick_input.h
@@ -36,6 +36,7 @@ class JoystickInput : public InputDevice {
   void ApplyAppConfig() override;
   void Update() override;
   void ResetHeldStates() override;
+  void Rumble(float low_freq, float high_freq, int duration_ms) override;
 
   auto sdl_joystick_id() const -> int { return sdl_joystick_id_; }
 

--- a/src/ballistica/base/networking/networking.h
+++ b/src/ballistica/base/networking/networking.h
@@ -102,6 +102,7 @@ namespace ballistica::base {
 #define BA_MESSAGE_CLIENT_PLAYER_PROFILES_JSON 21
 
 #define BA_JMESSAGE_SCREEN_MESSAGE 0
+#define BA_JMESSAGE_RUMBLE 1
 
 // Enable huffman compression for all net packets?
 #define BA_HUFFMAN_NET_COMPRESSION 1

--- a/src/ballistica/scene_v1/connection/connection_to_host.cc
+++ b/src/ballistica/scene_v1/connection/connection_to_host.cc
@@ -508,6 +508,25 @@ void ConnectionToHost::HandleMessagePacket(const std::vector<uint8_t>& buffer) {
                 }
                 break;
               }
+              case BA_JMESSAGE_RUMBLE: {
+                // The host addresses us by the local device-index we
+                // originally claimed a remote player with (see
+                // SceneV1InputDeviceDelegate::RequestPlayer()), so we can
+                // look it up directly and rumble it ourselves.
+                auto device_index = root["d"].as_int();
+                if (device_index) {
+                  if (base::InputDevice* input_device =
+                          g_base->input->GetInputDevice(
+                              static_cast<int>(*device_index))) {
+                    auto low = static_cast<float>(root["lo"].double_or(1.0));
+                    auto high = static_cast<float>(root["hi"].double_or(1.0));
+                    auto duration =
+                        static_cast<int>(root["ms"].int_or(150));
+                    input_device->Rumble(low, high, duration);
+                  }
+                }
+                break;
+              }
               default:
                 break;
             }

--- a/src/ballistica/scene_v1/connection/connection_to_host.cc
+++ b/src/ballistica/scene_v1/connection/connection_to_host.cc
@@ -520,8 +520,7 @@ void ConnectionToHost::HandleMessagePacket(const std::vector<uint8_t>& buffer) {
                               static_cast<int>(*device_index))) {
                     auto low = static_cast<float>(root["lo"].double_or(1.0));
                     auto high = static_cast<float>(root["hi"].double_or(1.0));
-                    auto duration =
-                        static_cast<int>(root["ms"].int_or(150));
+                    auto duration = static_cast<int>(root["ms"].int_or(150));
                     input_device->Rumble(low, high, duration);
                   }
                 }

--- a/src/ballistica/scene_v1/python/class/python_class_input_device.cc
+++ b/src/ballistica/scene_v1/python/class/python_class_input_device.cc
@@ -473,6 +473,30 @@ auto PythonClassInputDevice::GetButtonName(PythonClassInputDevice* self,
   BA_PYTHON_CATCH;
 }
 
+auto PythonClassInputDevice::Rumble(PythonClassInputDevice* self,
+                                    PyObject* args, PyObject* keywds)
+    -> PyObject* {
+  BA_PYTHON_TRY;
+  assert(g_base->InLogicThread());
+  float low_freq{1.0f};
+  float high_freq{1.0f};
+  int duration_ms{150};
+  static const char* kwlist[] = {"low_freq", "high_freq", "duration_ms",
+                                 nullptr};
+  if (!PyArg_ParseTupleAndKeywords(args, keywds, "|ffi",
+                                   const_cast<char**>(kwlist), &low_freq,
+                                   &high_freq, &duration_ms)) {
+    return nullptr;
+  }
+  SceneV1InputDeviceDelegate* d = self->input_device_delegate_->get();
+  if (!d) {
+    throw Exception(PyExcType::kInputDeviceNotFound);
+  }
+  d->input_device().Rumble(low_freq, high_freq, duration_ms);
+  Py_RETURN_NONE;
+  BA_PYTHON_CATCH;
+}
+
 PyTypeObject PythonClassInputDevice::type_obj;
 PyMethodDef PythonClassInputDevice::tp_methods[] = {
     {"detach_from_player", (PyCFunction)DetachFromPlayer, METH_NOARGS,
@@ -539,6 +563,20 @@ PyMethodDef PythonClassInputDevice::tp_methods[] = {
      "represent 'owns nothing'.\n"
      "\n"
      "(internal)"},
+    {"rumble", (PyCFunction)Rumble,
+     METH_VARARGS | METH_KEYWORDS,  // NOLINT (signed bitwise ops)
+     "rumble(low_freq: float = 1.0, high_freq: float = 1.0,\n"
+     "duration_ms: int = 150) -> None\n"
+     "\n"
+     "Trigger haptic feedback (controller rumble) on this device, if it\n"
+     "supports it.\n"
+     "\n"
+     "low_freq and high_freq are normalized motor intensities in the\n"
+     "0.0 to 1.0 range (mirrors dual-motor gamepad rumble: a\n"
+     "low-frequency 'strong' motor and a high-frequency 'weak' motor).\n"
+     "duration_ms is how long to sustain it. Devices that don't support\n"
+     "rumble (keyboards, touchscreens, remote clients without haptics,\n"
+     "etc.) simply ignore this call."},
     {nullptr}};  // namespace ballistica
 
 #pragma clang diagnostic pop

--- a/src/ballistica/scene_v1/python/class/python_class_input_device.h
+++ b/src/ballistica/scene_v1/python/class/python_class_input_device.h
@@ -43,6 +43,8 @@ class PythonClassInputDevice : public PythonClass {
                           PyObject* keywds) -> PyObject*;
   static auto GetButtonName(PythonClassInputDevice* self, PyObject* args,
                             PyObject* keywds) -> PyObject*;
+  static auto Rumble(PythonClassInputDevice* self, PyObject* args,
+                     PyObject* keywds) -> PyObject*;
   static PyNumberMethods as_number_;
   Object::WeakRef<SceneV1InputDeviceDelegate>* input_device_delegate_;
 };

--- a/src/ballistica/scene_v1/support/client_input_device.cc
+++ b/src/ballistica/scene_v1/support/client_input_device.cc
@@ -4,7 +4,9 @@
 
 #include <string>
 
+#include "ballistica/base/networking/networking.h"
 #include "ballistica/scene_v1/connection/connection_to_client.h"
+#include "ballistica/shared/generic/json_facade.h"
 
 namespace ballistica::scene_v1 {
 
@@ -21,6 +23,22 @@ ClientInputDevice::~ClientInputDevice() = default;
 
 auto ClientInputDevice::DoGetDeviceName() -> std::string {
   return "Client Input Device";
+}
+
+void ClientInputDevice::Rumble(float low_freq, float high_freq,
+                               int duration_ms) {
+  ConnectionToClient* connection = connection_to_client_.get();
+  if (!connection) {
+    return;
+  }
+  JsonBuilder builder;
+  builder.root_object()
+      .Add("t", BA_JMESSAGE_RUMBLE)
+      .Add("d", remote_device_id_)
+      .Add("lo", low_freq)
+      .Add("hi", high_freq)
+      .Add("ms", duration_ms);
+  connection->SendJMessage(builder.Write());
 }
 
 }  // namespace ballistica::scene_v1

--- a/src/ballistica/scene_v1/support/client_input_device.h
+++ b/src/ballistica/scene_v1/support/client_input_device.h
@@ -20,6 +20,11 @@ class ClientInputDevice : public base::InputDevice {
   auto DoGetDeviceName() -> std::string override;
   auto IsLocal() -> bool override { return false; }
 
+  /// Relay a rumble request across the network to this device's actual
+  /// owner (the remote client), targeted at the specific local device
+  /// they attached with. No-ops if the connection is gone.
+  void Rumble(float low_freq, float high_freq, int duration_ms) override;
+
   void PassInputCommand(InputType type, float value) {
     InputCommand(type, value);
   }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to Ballistica!

To ease the process of reviewing your PR, make sure to complete the following steps.

You can also read more about contributing to Ballistica in this document:
https://ballistica.net/wiki/Contributing
-->

## Steps

- [x] Write a good description of what your PR does (and WHY it does it).
- [x] Add yourself to CONTRIBUTORS if you are a new contributor.
- [ ] Add a CHANGELOG entry if your change is non-trivial. (I'd need some guidance here @efroemling)
- [x] Ensure `make preflight` completes successfully.

## Description

- Adds an `InputDevice::Rumble()` virtual (no-op by default), overridden by `JoystickInput` to call SDL3's `SDL_RumbleJoystick` on the owning main thread,
  and by `ClientInputDevice` to relay the request to a networked player's actual client over a new `BA_JMESSAGE_RUMBLE`.
- Triggers from real `HitMessage` handling in `Spaz`, scaled by damage taken — only the player actually getting hit feels it, never a broadcast to
  everyone's controller (a specific concern raised in the issue thread).
- Exposes it to Python via `bascenev1.InputDevice.rumble()` and a `Player.rumble()` convenience wrapper, so game/mod code can trigger haptics directly
  too.
- Adds a "Controller Vibration" on/off toggle and intensity slider under Settings → Controls.

## Testing

  - Built and ran on both Linux (cmake) and Windows (MSBuild) debug builds.
  - Hands-on tested on real hardware: DualShock4, DualSense, and Xbox Series S controllers.
  - Verified the networked path across a real host+client connection (two instances, not local splitscreen) — confirmed there's no loopback shortcut in the
  connection-accept path that would bypass the actual UDP/JSON relay.
  - Confirmed the settings toggle disables rumble entirely and the intensity slider scales it.

## Known limitations

- DualSense haptics are noticeably weaker than DualShock4/Xbox at identical intensity values. Checked SDL3's own hint defaults (`JOYSTICK_HIDAPI_PS5`,
  `ENHANCED_REPORTS`, etc.) — already optimal, so this looks like an inherent LRA-vs-ERM motor characteristic of SDL's basic rumble API rather than a config
  bug. A stronger fix would need `SDL_SendJoystickEffect` with DualSense's raw HID report format.
- No rate-limiting/cooldown on rapid repeated hits yet (SDL cancels-and-restarts on each call, so a hit flurry can feel choppy).
- No bound on host-supplied `duration_ms` on the networked path.
- Only wired up for SDL-backed platforms (Linux/Windows/Mac); mobile and other app-adapters currently inherit the no-op default.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
|-----|------------------------|
| ✓   | :sparkles: New feature |

## Related Issue

Closes #174 

## AI Disclosure

Majority of this code was assisted by Claude Sonnet 5.