### PR TITLE
fix kick vote : correct NO input and make NO votes count

### DIFF
--- a/src/ballistica/classic/support/classic_app_mode.cc
+++ b/src/ballistica/classic/support/classic_app_mode.cc
@@ -1026,7 +1026,7 @@ void ClassicAppMode::UpdateKickVote_() {
         votes_required = total_client_count - 3;
         break;
     }
-    int votes_needed = votes_required - yes_votes;
+    int votes_needed = votes_required - (yes_votes - no_votes);
     if (votes_needed <= 0) {
       // ZOMG the vote passed; perform the kick.
       connections()->SendScreenMessageToClients(

--- a/src/ballistica/scene_v1/connection/connection_to_client.cc
+++ b/src/ballistica/scene_v1/connection/connection_to_client.cc
@@ -812,9 +812,9 @@ void ConnectionToClient::HandleMessagePacket(
                     1, 0, 0);
               } else if (kick_vote_in_progress
                          && (!strcmp(b2.data(), "1")
-                             || !strcmp(b2.data(), "2"))) {
+                             || !strcmp(b2.data(), "0"))) {
                 // Special case - if there's a kick vote going on, take
-                // '1' or '2' to be votes.
+                // '1' or '0' to be votes.
                 // TODO(ericf): Disable this based on build-numbers once
                 // we've
                 //  got GUI voting working.


### PR DESCRIPTION
hey, noticed a couple issues with the kick vote system so i pushed a quick fix:

1. the game tells you to type '0' to vote no, but the code was actually looking for '2'. typing 0 literally did nothing. i changed the handler to just accept '0' to match the screen.
2. even if people did vote no, the `no_votes` variable was completely ignored in the final math (basically a placebo). i changed it so `no_votes` actually subtracts from `yes_votes` so the votes actually count now.