### PR TITLE
ci/cd enhancements

### DIFF
--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -1,3 +1,5 @@
+# Cache apt archives step is keyed on this file so any changes to it invalidate the cache.
+
 name: "Setup BombSquad Environment"
 description: "Common setup steps for BombSquad builds"
 
@@ -9,11 +11,19 @@ inputs:
     required: false
     type: boolean
     default: false
+  save-asset-cache:
+    description: |
+      "Set to true on exactly ONE job per workflow to have that job save"
+      "the shared bombsquad asset cache. Every other job restores only."
+      "Saving is additionally limited to the default branch; see the"
+      "asset cache steps below for why."
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -28,16 +38,26 @@ runs:
       with:
         enable-cache: true
         cache-dependency-glob: "pconfig/requirements.txt"
-    - name: Cache Bombsquad assets
-      id: cache-assets
-      uses: actions/cache@v5
+    # Restore-only. We deliberately do NOT key on hashFiles('.efrocachemap'):
+    # that file is regenerated on every single commit, so such a key can
+    # never hit and actions/cache would re-save the (~440MB) entry on every
+    # job of every run, which alone was consuming half of the repo's 10GB
+    # cache budget and evicting everything else.
+    #
+    # A stale restore is always correct here: .cache/efrocache is a
+    # content-addressed store (see get_local_cache_dir /
+    # get_existing_file_hash in tools/efrotools/efrocache.py), so the
+    # 'Update assets' step below re-fetches only the files whose hashes
+    # actually changed.
+    - name: Restore Bombsquad assets cache
+      uses: actions/cache/restore@v5
       env:
         cache-name: cache-bombsquad-assets
       with:
         path: |
           build/assets
           .cache/efrocache/
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('.efrocachemap') }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
     - name: Setup project environment
@@ -64,19 +84,51 @@ runs:
         done
         echo "::error::Asset assembly failed after 3 attempts." >&2
         exit 1
+    # Exactly one job (opted in via save-asset-cache) refreshes the shared
+    # cache, and only on the default branch. Caches written from a PR ref
+    # are scoped to that PR and can never be read by anything else, so
+    # saving there would just burn budget. Comparing against
+    # default_branch rather than a hardcoded 'main' keeps this working in
+    # forks too.
+    - name: Save Bombsquad assets cache
+      if: ${{ inputs.save-asset-cache == 'true'
+        && github.ref_name == github.event.repository.default_branch }}
+      uses: actions/cache/save@v5
+      env:
+        cache-name: cache-bombsquad-assets
+      with:
+        path: |
+          build/assets
+          .cache/efrocache/
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
+
     # Following steps only run for inputs.using-cmake == 'true'
-    - name: Install build packgages
+    - name: Cache apt archives
+      if: ${{ inputs.using-cmake == 'true' }}
+      uses: actions/cache@v5
+      with:
+        path: .cache/apt-archives
+        key: ${{ runner.os }}-${{ runner.arch }}-apt-${{ hashFiles('.github/actions/bombsquad_build_env/action.yml') }}
+    - name: Install build packages
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash
       run: |
-        sudo apt-get update -qq
+        # apt drops privileges to _apt to download, so it needs to own the
+        # archive dir; we take it back afterwards so the cache save (which
+        # runs as the runner user) can read it.
+        mkdir -p .cache/apt-archives/partial
+        sudo chown -R _apt:root .cache/apt-archives
+        sudo apt-get update -qq -o Acquire::Languages=none
         sudo apt-get install -y --no-install-recommends \
+          -o Dir::Cache::archives="$PWD/.cache/apt-archives" \
           libglut-dev \
           libopenal-dev \
           libvorbis-dev \
           libpango1.0-dev \
           ninja-build \
           libsdl3-dev
+
+        sudo chown -R "$(id -u):$(id -g)" .cache/apt-archives
     - name: Setup env variables
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash
@@ -86,6 +138,6 @@ runs:
         echo CMAKE_EXTRA_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
     - name: Setup sccache
       if: ${{ inputs.using-cmake == 'true' }}
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@v0.0.11
       with:
         disable_annotations: true

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -97,22 +97,23 @@ runs:
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash
       run: |
-        # apt drops privileges to _apt to download, so it needs to own the
-        # archive dir; we take it back afterwards so the cache save (which
-        # runs as the runner user) can read it.
+        # apt's fetch sandbox drops to the _apt user, which can't reach an
+        # archive dir inside the runner workspace -- apt notices and falls
+        # back to fetching as root anyway, just with a warning per package.
+        # Ask for that fallback explicitly so it isn't noise. Downloads then
+        # land as root:root 0644, which the cache save (running as the
+        # runner user) can still read.
         mkdir -p .cache/apt-archives/partial
-        sudo chown -R _apt:root .cache/apt-archives
         sudo apt-get update -qq -o Acquire::Languages=none
         sudo apt-get install -y --no-install-recommends \
           -o Dir::Cache::archives="$PWD/.cache/apt-archives" \
+          -o APT::Sandbox::User=root \
           libglut-dev \
           libopenal-dev \
           libvorbis-dev \
           libpango1.0-dev \
           ninja-build \
           libsdl3-dev
-
-        sudo chown -R "$(id -u):$(id -g)" .cache/apt-archives
     - name: Setup env variables
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -11,15 +11,6 @@ inputs:
     required: false
     type: boolean
     default: false
-  save-asset-cache:
-    description: |
-      "Set to true on exactly ONE job per workflow to have that job save"
-      "the shared bombsquad asset cache. Every other job restores only."
-      "Saving is additionally limited to the default branch; see the"
-      "asset cache steps below for why."
-    required: false
-    type: boolean
-    default: false
 
 runs:
   using: "composite"
@@ -38,26 +29,32 @@ runs:
       with:
         enable-cache: true
         cache-dependency-glob: "pconfig/requirements.txt"
-    # Restore-only. We deliberately do NOT key on hashFiles('.efrocachemap'):
-    # that file is regenerated on every single commit, so such a key can
-    # never hit and actions/cache would re-save the (~440MB) entry on every
-    # job of every run, which alone was consuming half of the repo's 10GB
-    # cache budget and evicting everything else.
+    # Keyed on the UTC date, NOT hashFiles('.efrocachemap'): that file is
+    # regenerated on every single commit, so such a key can never hit,
+    # which made this mint a fresh ~440MB entry per commit (6 in one day,
+    # observed) and crowd the repo's 10GB budget. A date key throttles
+    # that to one entry per day for free -- actions/cache does not save
+    # when the primary key hits exactly, so only the day's first job
+    # saves and the rest just restore.
     #
     # A stale restore is always correct here: .cache/efrocache is a
     # content-addressed store (see get_local_cache_dir /
     # get_existing_file_hash in tools/efrotools/efrocache.py), so the
     # 'Update assets' step below re-fetches only the files whose hashes
-    # actually changed.
-    - name: Restore Bombsquad assets cache
-      uses: actions/cache/restore@v5
+    # actually changed. A day of drift is cheap.
+    - name: Compute asset cache day
+      id: asset-day
+      shell: bash
+      run: echo "day=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+    - name: Cache Bombsquad assets
+      uses: actions/cache@v5
       env:
         cache-name: cache-bombsquad-assets
       with:
         path: |
           build/assets
           .cache/efrocache/
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.asset-day.outputs.day }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
     - name: Setup project environment
@@ -84,24 +81,6 @@ runs:
         done
         echo "::error::Asset assembly failed after 3 attempts." >&2
         exit 1
-    # Exactly one job (opted in via save-asset-cache) refreshes the shared
-    # cache, and only on the default branch. Caches written from a PR ref
-    # are scoped to that PR and can never be read by anything else, so
-    # saving there would just burn budget. Comparing against
-    # default_branch rather than a hardcoded 'main' keeps this working in
-    # forks too.
-    - name: Save Bombsquad assets cache
-      if: ${{ inputs.save-asset-cache == 'true'
-        && github.ref_name == github.event.repository.default_branch }}
-      uses: actions/cache/save@v5
-      env:
-        cache-name: cache-bombsquad-assets
-      with:
-        path: |
-          build/assets
-          .cache/efrocache/
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
-
     # Following steps only run for inputs.using-cmake == 'true'
     - name: Cache apt archives
       if: ${{ inputs.using-cmake == 'true' }}

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -100,9 +100,7 @@ runs:
         # apt's fetch sandbox drops to the _apt user, which can't reach an
         # archive dir inside the runner workspace -- apt notices and falls
         # back to fetching as root anyway, just with a warning per package.
-        # Ask for that fallback explicitly so it isn't noise. Downloads then
-        # land as root:root 0644, which the cache save (running as the
-        # runner user) can still read.
+        # Ask for that fallback explicitly so it isn't noise.
         mkdir -p .cache/apt-archives/partial
         sudo apt-get update -qq -o Acquire::Languages=none
         sudo apt-get install -y --no-install-recommends \
@@ -114,6 +112,14 @@ runs:
           libpango1.0-dev \
           ninja-build \
           libsdl3-dev
+
+        # Running unsandboxed means apt leaves root-owned droppings here.
+        # The .debs are 0644 and readable, but 'lock' is 0640 and 'partial'
+        # is root-owned too, which makes the cache save's tar bail out.
+        # Neither is worth caching, so drop them; chown the rest back so
+        # tar (running as the runner user) can read everything left.
+        sudo rm -rf .cache/apt-archives/lock .cache/apt-archives/partial
+        sudo chown -R "$(id -u):$(id -g)" .cache/apt-archives
     - name: Setup env variables
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -1,5 +1,3 @@
-# Cache apt archives step is keyed on this file so any changes to it invalidate the cache.
-
 name: "Setup BombSquad Environment"
 description: "Common setup steps for BombSquad builds"
 
@@ -87,39 +85,19 @@ runs:
         exit 1
 
     # Following steps only run for inputs.using-cmake == 'true'
-    - name: Cache apt archives
-      if: ${{ inputs.using-cmake == 'true' }}
-      uses: actions/cache@v6
-      with:
-        path: .cache/apt-archives
-        key: ${{ runner.os }}-${{ runner.arch }}-apt-${{ hashFiles('.github/actions/bombsquad_build_env/action.yml') }}
+
     - name: Install build packages
       if: ${{ inputs.using-cmake == 'true' }}
-      shell: bash
-      run: |
-        # apt's fetch sandbox drops to the _apt user, which can't reach an
-        # archive dir inside the runner workspace -- apt notices and falls
-        # back to fetching as root anyway, just with a warning per package.
-        # Ask for that fallback explicitly so it isn't noise.
-        mkdir -p .cache/apt-archives/partial
-        sudo apt-get update -qq -o Acquire::Languages=none
-        sudo apt-get install -y --no-install-recommends \
-          -o Dir::Cache::archives="$PWD/.cache/apt-archives" \
-          -o APT::Sandbox::User=root \
-          libglut-dev \
-          libopenal-dev \
-          libvorbis-dev \
-          libpango1.0-dev \
-          ninja-build \
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+      with:
+        packages: >-
+          libglut-dev
+          libopenal-dev
+          libvorbis-dev
+          libpango1.0-dev
+          ninja-build
           libsdl3-dev
 
-        # Running unsandboxed means apt leaves root-owned droppings here.
-        # The .debs are 0644 and readable, but 'lock' is 0640 and 'partial'
-        # is root-owned too, which makes the cache save's tar bail out.
-        # Neither is worth caching, so drop them; chown the rest back so
-        # tar (running as the runner user) can read everything left.
-        sudo rm -rf .cache/apt-archives/lock .cache/apt-archives/partial
-        sudo chown -R "$(id -u):$(id -g)" .cache/apt-archives
     - name: Setup env variables
       if: ${{ inputs.using-cmake == 'true' }}
       shell: bash
@@ -127,6 +105,7 @@ runs:
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
         echo "BA_APP_RUN_ENABLE_BUILDS=1" >> $GITHUB_ENV
         echo CMAKE_EXTRA_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
     - name: Setup sccache
       if: ${{ inputs.using-cmake == 'true' }}
       uses: mozilla-actions/sccache-action@v0.0.11

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.14"
 
@@ -31,30 +31,18 @@ runs:
         enable-cache: true
         cache-dependency-glob: "pconfig/requirements.txt"
 
-    # Keyed on just the build/assets/ slice of .efrocachemap rather than the
-    # whole file. That file is 1687 build/assets/ entries plus 44
-    # build/prefab/ entries, and the prefab ones (prebuilt binaries, which
-    # this cache does not hold) churn on ~60% of commits while the asset
-    # entries change on ~13%. Hashing the whole file therefore threw this
-    # cache away 53 times per 100 commits for reasons unrelated to its
-    # contents; hashing only the assets slice: 9 times.
+    # Hash only the build/assets/ slice of .efrocachemap. The rest of that
+    # file is build/prefab/ entries (prebuilt binaries we don't cache here)
+    # which churn far more often, so a whole-file hash discarded this cache
+    # 53 times per 100 commits vs 9 for the slice.
     #
-    # A stale restore via restore-keys is always safe: efrocache is
-    # content-addressed, so the 'Update assets' step below re-fetches only
-    # the files whose hashes actually changed (see get_target in
-    # tools/efrotools/efrocache.py).
+    # .cache/efrocache is deliberately not cached: get_target() (see
+    # tools/efrotools/efrocache.py) skips it entirely when build/assets is
+    # already in place, and can't hold the new hashes when it isn't. Stale
+    # restores via restore-keys are safe for the same reason -- only
+    # genuinely changed files get re-fetched.
     #
-    # .cache/efrocache is deliberately NOT cached here. get_target() returns
-    # early when the target file is already in place with a matching hash,
-    # without ever consulting that dir, so it goes unread whenever
-    # build/assets restores intact -- and when build/assets is stale the
-    # wanted hashes are new, so an older efrocache could not hold them
-    # either. It is 8x the size of build/assets, nothing ever prunes it, and
-    # its only real consumer (warm_start_cache, reached solely by the
-    # 'make test-ex' job) just re-fetches a 3MB starter archive without it.
-    #
-    # Bump the -v1- token to force a cold rebuild if build/assets ever
-    # accumulates orphaned files across a long restore-key chain.
+    # Bump the -v1- token to force a cold rebuild.
     - name: Compute asset cache key
       id: asset-key
       shell: bash

--- a/.github/actions/bombsquad_build_env/action.yml
+++ b/.github/actions/bombsquad_build_env/action.yml
@@ -19,47 +19,63 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.14"
+
     # ``make env`` builds the project venv via uv (uv venv +
     # uv pip install ...), so uv must be on PATH before that runs.
     # ``setup-uv`` is the official Astral-published action; it
     # installs uv and uses requirements.txt-keyed caching the same
     # way ``setup-python``'s ``cache: pip`` did before this switch.
     - name: Set up uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         enable-cache: true
         cache-dependency-glob: "pconfig/requirements.txt"
-    # Keyed on the UTC date, NOT hashFiles('.efrocachemap'): that file is
-    # regenerated on every single commit, so such a key can never hit,
-    # which made this mint a fresh ~440MB entry per commit (6 in one day,
-    # observed) and crowd the repo's 10GB budget. A date key throttles
-    # that to one entry per day for free -- actions/cache does not save
-    # when the primary key hits exactly, so only the day's first job
-    # saves and the rest just restore.
+
+    # Keyed on just the build/assets/ slice of .efrocachemap rather than the
+    # whole file. That file is 1687 build/assets/ entries plus 44
+    # build/prefab/ entries, and the prefab ones (prebuilt binaries, which
+    # this cache does not hold) churn on ~60% of commits while the asset
+    # entries change on ~13%. Hashing the whole file therefore threw this
+    # cache away 53 times per 100 commits for reasons unrelated to its
+    # contents; hashing only the assets slice: 9 times.
     #
-    # A stale restore is always correct here: .cache/efrocache is a
-    # content-addressed store (see get_local_cache_dir /
-    # get_existing_file_hash in tools/efrotools/efrocache.py), so the
-    # 'Update assets' step below re-fetches only the files whose hashes
-    # actually changed. A day of drift is cheap.
-    - name: Compute asset cache day
-      id: asset-day
+    # A stale restore via restore-keys is always safe: efrocache is
+    # content-addressed, so the 'Update assets' step below re-fetches only
+    # the files whose hashes actually changed (see get_target in
+    # tools/efrotools/efrocache.py).
+    #
+    # .cache/efrocache is deliberately NOT cached here. get_target() returns
+    # early when the target file is already in place with a matching hash,
+    # without ever consulting that dir, so it goes unread whenever
+    # build/assets restores intact -- and when build/assets is stale the
+    # wanted hashes are new, so an older efrocache could not hold them
+    # either. It is 8x the size of build/assets, nothing ever prunes it, and
+    # its only real consumer (warm_start_cache, reached solely by the
+    # 'make test-ex' job) just re-fetches a 3MB starter archive without it.
+    #
+    # Bump the -v1- token to force a cold rebuild if build/assets ever
+    # accumulates orphaned files across a long restore-key chain.
+    - name: Compute asset cache key
+      id: asset-key
       shell: bash
-      run: echo "day=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "hash=$(grep '"build/assets/' .efrocachemap \
+          | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
     - name: Cache Bombsquad assets
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
         cache-name: cache-bombsquad-assets
       with:
-        path: |
-          build/assets
-          .cache/efrocache/
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.asset-day.outputs.day }}
+        path: build/assets
+        key: ${{ runner.os }}-${{ env.cache-name }}-v1-${{ steps.asset-key.outputs.hash }}
         restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}-v1-
+
     - name: Setup project environment
       shell: bash
       run: make env
+
     - name: Update assets
       shell: bash
       # These targets assemble bundled builtin assets by calling the
@@ -81,10 +97,11 @@ runs:
         done
         echo "::error::Asset assembly failed after 3 attempts." >&2
         exit 1
+
     # Following steps only run for inputs.using-cmake == 'true'
     - name: Cache apt archives
       if: ${{ inputs.using-cmake == 'true' }}
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: .cache/apt-archives
         key: ${{ runner.os }}-${{ runner.arch }}-apt-${{ hashFiles('.github/actions/bombsquad_build_env/action.yml') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "area/ci"
+      - "kind/update"
+      - "priority/low"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
         uses: ./.github/actions/bombsquad_build_env
         with:
           using-cmake: true
-          # This job is the one that refreshes the shared asset cache for
-          # the repo (it runs on every push and isn't arch-specific). All
-          # other jobs everywhere else restore only.
-          save-asset-cache: true
       - name: Run checks
         run: BA_PCOMMANDBATCH_BUILD_REQUIRE=1 make check-ex
       - name: Verify asset-package pins are prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
         uses: ./.github/actions/bombsquad_build_env
         with:
           using-cmake: true
+          # This job is the one that refreshes the shared asset cache for
+          # the repo (it runs on every push and isn't arch-specific). All
+          # other jobs everywhere else restore only.
+          save-asset-cache: true
       - name: Run checks
         run: BA_PCOMMANDBATCH_BUILD_REQUIRE=1 make check-ex
       - name: Verify asset-package pins are prod

--- a/pconfig/spinoffconfig.py
+++ b/pconfig/spinoffconfig.py
@@ -206,6 +206,7 @@ ctx.filter_file_names = {
     'cd.yaml',
     'deploy_docs.yaml',
     'release.yaml',
+    'dependabot.yml',
     'LICENSE',
     'cloudtool',
     'bacloud',


### PR DESCRIPTION
Changes in this pr
- Enables dependabot to auto update the action versions monthly
- Changed caching strategy for bombsquad assets
  - Not caching .cache/efrocache anymore
  - Cache key is computed from .efrocachemap's build/asset entries only(ignored build/prefab and src/ballistica keys) which invalidates the cache less often and as a result also doesnt generate new cache entries unless build/asset changed
- Added caching for apt packages which were taking too long to install